### PR TITLE
[FEATURE] 게시글 임시 저장 구현 + Post 엔티티 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/common/application/ImageValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/common/application/ImageValidator.java
@@ -15,10 +15,6 @@ import lombok.RequiredArgsConstructor;
 public class ImageValidator {
 
 	public List<MultipartFile> filterValidImages(List<MultipartFile> images) {
-		if (images == null) {
-			return List.of(); // null인 경우 빈 리스트 반환
-		}
-
 		return images.stream()
 			.filter(image -> image != null && image.getOriginalFilename() != null && !image.getOriginalFilename().isEmpty())
 			.toList();

--- a/src/main/java/com/cotato/kampus/domain/post/api/PostController.java
+++ b/src/main/java/com/cotato/kampus/domain/post/api/PostController.java
@@ -21,6 +21,7 @@ import com.cotato.kampus.domain.post.dto.response.MyPostResponse;
 import com.cotato.kampus.domain.post.dto.response.PostCreateResponse;
 import com.cotato.kampus.domain.post.dto.response.PostDeleteResponse;
 import com.cotato.kampus.domain.post.dto.response.PostDetailResponse;
+import com.cotato.kampus.domain.post.dto.response.PostDraftResponse;
 import com.cotato.kampus.domain.post.dto.response.PostSliceFindResponse;
 import com.cotato.kampus.global.common.dto.DataResponse;
 import com.cotato.kampus.global.error.exception.ImageException;
@@ -40,7 +41,7 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@Operation(summary = "게시글 생성", description = "게시글 생성 요청입니다.")
+	@Operation(summary = "게시글 생성", description = "게시글 생성 요청입니다. 사진이 없는 경우 빈 값('')을 보내지 말고, 해당 필드를 생략하거나 값을 보내지 않도록 해주세요.")
 	public ResponseEntity<DataResponse<PostCreateResponse>> createPost(
 		@Parameter(description = "Post creation request")
 		@ModelAttribute PostCreateRequest request) throws ImageException {
@@ -52,7 +53,26 @@ public class PostController {
 					request.content(),
 					request.postCategory(),
 					request.anonymity(),
-					request.images()
+					request.images() == null ? List.of() : request.images()
+				)
+			)
+		));
+	}
+
+	@PostMapping(value = "/draft", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "게시글 임시 저장", description = "게시글을 임시 저장합니다. boardId, anonymity(ANONYMOUS)는 필수 값입니다. 사진이 없는 경우 빈 값('')을 보내지 말고, 해당 필드를 생략하거나 값을 보내지 않도록 해주세요.")
+	public ResponseEntity<DataResponse<PostDraftResponse>> draftPost(
+		@Parameter(description = "Post creation request")
+		@ModelAttribute PostCreateRequest request) throws ImageException {
+		return ResponseEntity.ok(DataResponse.from(
+			PostDraftResponse.of(
+				postService.draftPost(
+					request.boardId(),
+					request.title(),
+					request.content(),
+					request.postCategory(),
+					request.anonymity(),
+					request.images() == null ? List.of() : request.images()
 				)
 			)
 		));

--- a/src/main/java/com/cotato/kampus/domain/post/application/PostAppender.java
+++ b/src/main/java/com/cotato/kampus/domain/post/application/PostAppender.java
@@ -39,10 +39,34 @@ public class PostAppender {
 			.content(content)
 			.likes(0L)
 			.scraps(0L)
+			.comments(0L)
 			.anonymity(anonymity)
 			.postStatus(PostStatus.PUBLISHED)
 			.postCategory(postCategory)
 			.nextAnonymousNumber(1L)
+			.build();
+
+		return postRepository.save(post).getId();
+	}
+
+	@Transactional
+	public Long draft(
+		Long boardId,
+		String title,
+		String content,
+		PostCategory postCategory,
+		Anonymity anonymity
+	){
+		Long userId = apiUserResolver.getUserId();
+
+		Post post = Post.builder()
+			.userId(userId)
+			.boardId(boardId)
+			.title(title)
+			.content(content)
+			.anonymity(anonymity)
+			.postStatus(PostStatus.DRAFT)
+			.postCategory(postCategory)
 			.build();
 
 		return postRepository.save(post).getId();

--- a/src/main/java/com/cotato/kampus/domain/post/application/PostScrapValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/post/application/PostScrapValidator.java
@@ -19,10 +19,9 @@ public class PostScrapValidator {
 	private final PostAuthorResolver postAuthorResolver;
 
 	public void validatePostScrap(Long postId, Long userId){
-		Long authorId = postAuthorResolver.getAuthorId(postId);
 
 		// 본인 게시글 또는 이미 스크랩한 게시글은 예외처리
-		if(userId.equals(authorId)){
+		if(postAuthorResolver.validatePostAuthor(postId, userId)){
 			throw new AppException(ErrorCode.POST_SCRAP_FORBIDDEN);
 		}
 

--- a/src/main/java/com/cotato/kampus/domain/post/application/PostValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/post/application/PostValidator.java
@@ -1,0 +1,28 @@
+package com.cotato.kampus.domain.post.application;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.kampus.domain.common.enums.Anonymity;
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.AppException;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Transactional(readOnly = true)
+public class PostValidator {
+
+	public void validatePublishable(
+		Long boardId,
+		String title,
+		String content,
+		Anonymity anonymity
+	){
+		if(boardId == null || title == null || content == null || anonymity == null){
+			throw new AppException(ErrorCode.POST_PUBLISH_INVALID);
+		}
+	}
+}

--- a/src/main/java/com/cotato/kampus/domain/post/domain/Post.java
+++ b/src/main/java/com/cotato/kampus/domain/post/domain/Post.java
@@ -35,23 +35,23 @@ public class Post extends BaseTimeEntity {
 	@Column(name = "board_id", nullable = false)
 	private Long boardId;
 
-	@Column(name = "title", nullable = false)
+	@Column(name = "title")
 	private String title;
 
-	@Column(name = "content", nullable = false, columnDefinition = "text")
+	@Column(name = "content", columnDefinition = "text")
 	private String content;
 
-	@Column(name = "likes", nullable = false)
+	@Column(name = "likes")
 	private Long likes = 0L;
 
-	@Column(name = "scraps", nullable = false)
+	@Column(name = "scraps")
 	private Long scraps = 0L;
 
-	@Column(name = "comments", nullable = false)
+	@Column(name = "comments")
 	private Long comments = 0L;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "anonymity", nullable = false)
+	@Column(name = "anonymity")
 	private Anonymity anonymity;
 
 	@Enumerated(EnumType.STRING)
@@ -59,15 +59,15 @@ public class Post extends BaseTimeEntity {
 	private PostStatus postStatus;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "post_category", nullable = false)
+	@Column(name = "post_category")
 	private PostCategory postCategory;
 
-	@Column(name = "next_ananymous_number", nullable = false)
+	@Column(name = "next_ananymous_number")
 	private Long nextAnonymousNumber = 1L;
 
 	@Builder
 	public Post(Long userId, Long boardId, String title, String content,
-		Long likes, Long scraps, Anonymity anonymity,
+		Long likes, Long scraps, Long comments, Anonymity anonymity,
 		PostStatus postStatus, PostCategory postCategory, Long nextAnonymousNumber) {
 		this.userId = userId;
 		this.boardId = boardId;
@@ -75,6 +75,7 @@ public class Post extends BaseTimeEntity {
 		this.content = content;
 		this.likes = likes;
 		this.scraps = scraps;
+		this.comments = comments;
 		this.anonymity = anonymity;
 		this.postStatus = postStatus;
 		this.postCategory = postCategory;

--- a/src/main/java/com/cotato/kampus/domain/post/dto/response/PostDraftResponse.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dto/response/PostDraftResponse.java
@@ -1,0 +1,7 @@
+package com.cotato.kampus.domain.post.dto.response;
+
+public record PostDraftResponse(Long postId) {
+	public static PostDraftResponse of(Long id) {
+		return new PostDraftResponse(id);
+	}
+}

--- a/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
+++ b/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	POST_SCRAP_FORBIDDEN(HttpStatus.FORBIDDEN, "자신의 게시글을 스크랩 할 수 없습니다.", "POST-005"),
 	POST_SCRAP_DUPLICATED(HttpStatus.FORBIDDEN, "이미 스크랩한 글입니다.", "POST-006"),
 	POST_SCRAP_NOT_EXIST(HttpStatus.FORBIDDEN, "스크랩 되지 않은 게시글은 삭제할 수 없습니다.", "POST-007"),
+	POST_PUBLISH_INVALID(HttpStatus.BAD_REQUEST, "게시글을 게시할 수 없습니다. 필수 항목이 누락되었습니다.", "POST-008"),
 
 	//Comment
 	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다.", "COMMENT-001"),


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
임시 저장 기능을 고려해서 Post 엔티티의 일부 필드 null 허용
게시글 생성 요청에서 필수 값 검증 로직 추가
임시 저장 기능 구현

### 상세 내용(Describe your changes)
<img width="930" alt="image" src="https://github.com/user-attachments/assets/8917c15b-80c6-4c26-9217-32d036755ea4" />

** 필수 값 **
boardId
anonymity (ANONYMOUS) -> 추후 익명으로만 작성하도록 수정 예정


```
{
  "status": "string",
  "timestamp": "2025-01-27T05:44:31.677Z",
  "data": {
    "postId": 9007199254740991
  }
}
```
### Issue Number or Link
#53 