### PR TITLE
[FEATURE] 카카오 소셜 로그인 후 회원 정보 수정 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/cotato/kampus/domain/user/api/UserController.java
+++ b/src/main/java/com/cotato/kampus/domain/user/api/UserController.java
@@ -13,6 +13,7 @@ import com.cotato.kampus.global.common.dto.DataResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +28,7 @@ public class UserController {
 	@PatchMapping("/details")
 	@Operation(summary = "소셜 로그인(카카오) 이후 유저 세부정보 저장(변경) api", description = "닉네임, 국적, 선호 언어 변경")
 	public ResponseEntity<DataResponse<UserDetailsUpdateResponse>> updateUserDetails(
-		@RequestBody UserDetailsUpdateRequest request) {
+		@RequestBody @Valid UserDetailsUpdateRequest request) {
 		return ResponseEntity.ok(
 			DataResponse.from(
 				UserDetailsUpdateResponse.from(

--- a/src/main/java/com/cotato/kampus/domain/user/api/UserController.java
+++ b/src/main/java/com/cotato/kampus/domain/user/api/UserController.java
@@ -1,0 +1,41 @@
+package com.cotato.kampus.domain.user.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cotato.kampus.domain.user.application.UserService;
+import com.cotato.kampus.domain.user.dto.request.UserDetailsUpdateRequest;
+import com.cotato.kampus.domain.user.dto.response.UserDetailsUpdateResponse;
+import com.cotato.kampus.global.common.dto.DataResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "유저 API", description = "User 관련 API")
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequestMapping("/v1/api/users")
+public class UserController {
+
+	private final UserService userService;
+
+	@PatchMapping("/details")
+	@Operation(summary = "소셜 로그인(카카오) 이후 유저 세부정보 저장(변경) api", description = "닉네임, 국적, 선호 언어 변경")
+	public ResponseEntity<DataResponse<UserDetailsUpdateResponse>> updateUserDetails(
+		@RequestBody UserDetailsUpdateRequest request) {
+		return ResponseEntity.ok(
+			DataResponse.from(
+				UserDetailsUpdateResponse.from(
+					userService.updateUserDetails(
+						request.nickname(), request.nationality(), request.preferredLanguage()
+					)
+				)
+			)
+		);
+	}
+}

--- a/src/main/java/com/cotato/kampus/domain/user/application/UserFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/user/application/UserFinder.java
@@ -2,7 +2,6 @@ package com.cotato.kampus.domain.user.application;
 
 import org.springframework.stereotype.Component;
 
-import com.cotato.kampus.domain.common.application.ApiUserResolver;
 import com.cotato.kampus.domain.user.dao.UserRepository;
 import com.cotato.kampus.domain.user.domain.User;
 import com.cotato.kampus.global.error.ErrorCode;
@@ -22,9 +21,12 @@ public class UserFinder {
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 	}
 
-	public User findById(Long userId){
+	public User findById(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 	}
 
+	public Boolean existsByNickname(String nickname) {
+		return userRepository.existsByNickname(nickname);
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/user/application/UserService.java
+++ b/src/main/java/com/cotato/kampus/domain/user/application/UserService.java
@@ -1,0 +1,22 @@
+package com.cotato.kampus.domain.user.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.kampus.domain.user.enums.Nationality;
+import com.cotato.kampus.domain.user.enums.PreferredLanguage;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class UserService {
+
+	private final UserUpdater userUpdater;
+
+	@Transactional
+	public Long updateUserDetails(String nickname, Nationality nationality, PreferredLanguage preferredLanguage) {
+		return userUpdater.updateDetails(nickname, nationality, preferredLanguage);
+	}
+}

--- a/src/main/java/com/cotato/kampus/domain/user/application/UserService.java
+++ b/src/main/java/com/cotato/kampus/domain/user/application/UserService.java
@@ -14,9 +14,11 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserUpdater userUpdater;
+	private final UserValidator userValidator;
 
 	@Transactional
 	public Long updateUserDetails(String nickname, Nationality nationality, PreferredLanguage preferredLanguage) {
+		userValidator.validateDuplicatedNickname(nickname);
 		return userUpdater.updateDetails(nickname, nationality, preferredLanguage);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/user/application/UserUpdater.java
+++ b/src/main/java/com/cotato/kampus/domain/user/application/UserUpdater.java
@@ -1,0 +1,27 @@
+package com.cotato.kampus.domain.user.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.kampus.domain.common.application.ApiUserResolver;
+import com.cotato.kampus.domain.user.domain.User;
+import com.cotato.kampus.domain.user.enums.Nationality;
+import com.cotato.kampus.domain.user.enums.PreferredLanguage;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserUpdater {
+
+	private final ApiUserResolver apiUserResolver;
+
+	@Transactional
+	public Long updateDetails(String nickname, Nationality nationality, PreferredLanguage preferredLanguage) {
+		User user = apiUserResolver.getUser();
+		user.updateDetails(nickname, nationality, preferredLanguage);
+		return user.getId();
+	}
+}

--- a/src/main/java/com/cotato/kampus/domain/user/application/UserValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/user/application/UserValidator.java
@@ -4,8 +4,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.common.application.ApiUserResolver;
-import com.cotato.kampus.domain.post.application.PostAuthorResolver;
-import com.cotato.kampus.domain.post.application.PostFinder;
 import com.cotato.kampus.domain.user.domain.User;
 import com.cotato.kampus.domain.user.enums.UserRole;
 import com.cotato.kampus.global.error.ErrorCode;
@@ -18,13 +16,19 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserValidator {
-	public final ApiUserResolver apiUserResolver;
-	public final PostAuthorResolver postFinder;
+	private final ApiUserResolver apiUserResolver;
+	private final UserFinder userFinder;
 
 	public void validateStudentVerification() {
 		User user = apiUserResolver.getUser();
 
 		if (user.getUserRole() == UserRole.UNVERIFIED)
 			throw new AppException(ErrorCode.USER_UNVERIFIED);
+	}
+
+	public void validateDuplicatedNickname(String nickname) {
+		if (userFinder.existsByNickname(nickname)) {
+			throw new AppException(ErrorCode.USER_NICKNAME_DUPLICATED);
+		}
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dao/UserRepository.java
@@ -9,4 +9,6 @@ import com.cotato.kampus.domain.user.domain.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByUniqueId(String uniqueId);
+
+	Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/cotato/kampus/domain/user/domain/User.java
+++ b/src/main/java/com/cotato/kampus/domain/user/domain/User.java
@@ -80,4 +80,11 @@ public class User {
 		this.username = username;
 		return this;
 	}
+
+	public User updateDetails(String nickname, Nationality nationality, PreferredLanguage preferredLanguage) {
+		this.nickname = nickname;
+		this.nationality = nationality;
+		this.preferredLanguage = preferredLanguage;
+		return this;
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/user/dto/request/UserDetailsUpdateRequest.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dto/request/UserDetailsUpdateRequest.java
@@ -3,9 +3,17 @@ package com.cotato.kampus.domain.user.dto.request;
 import com.cotato.kampus.domain.user.enums.Nationality;
 import com.cotato.kampus.domain.user.enums.PreferredLanguage;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
 public record UserDetailsUpdateRequest(
+	@NotBlank
+	@Pattern(regexp = "^[a-z]{5,20}$", message = "닉네임은 5~20자의 영어 소문자(a-z)만 입력 가능합니다.")
 	String nickname,
+	@NotNull(message = "국적을 입력해야 합니다.")
 	Nationality nationality,
+	@NotNull(message = "선호 언어를 입력해야 합니다.")
 	PreferredLanguage preferredLanguage
 ) {
 }

--- a/src/main/java/com/cotato/kampus/domain/user/dto/request/UserDetailsUpdateRequest.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dto/request/UserDetailsUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.cotato.kampus.domain.user.dto.request;
+
+import com.cotato.kampus.domain.user.enums.Nationality;
+import com.cotato.kampus.domain.user.enums.PreferredLanguage;
+
+public record UserDetailsUpdateRequest(
+	String nickname,
+	Nationality nationality,
+	PreferredLanguage preferredLanguage
+) {
+}

--- a/src/main/java/com/cotato/kampus/domain/user/dto/response/UserDetailsUpdateResponse.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dto/response/UserDetailsUpdateResponse.java
@@ -1,0 +1,9 @@
+package com.cotato.kampus.domain.user.dto.response;
+
+public record UserDetailsUpdateResponse(
+	Long userId
+) {
+	public static UserDetailsUpdateResponse from(Long id) {
+		return new UserDetailsUpdateResponse(id);
+	}
+}

--- a/src/main/java/com/cotato/kampus/global/auth/oauth/handler/OAuthSuccessHandler.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/handler/OAuthSuccessHandler.java
@@ -29,7 +29,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 	private static final String ACCESS_HEADER_NAME = "Authorization";
 	private static final String REFRESH_HEADER_NAME = "Refresh-Token";
 	private static final String TOKEN_PREFIX = "Bearer";
-	private static final Long ACCESS_TOKEN_EXP = 6000000L;
+	private static final Long ACCESS_TOKEN_EXP = 604800000L; // 일주일
 	private static final Long REFRESH_TOKEN_EXP = 86400000L;
 	private static final String REDIRECT_URL = "kampus://login";
 

--- a/src/main/java/com/cotato/kampus/global/auth/oauth/service/dto/OAuth2Attribute.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/service/dto/OAuth2Attribute.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.cotato.kampus.domain.user.domain.User;
 import com.cotato.kampus.domain.user.enums.Nationality;
+import com.cotato.kampus.domain.user.enums.PreferredLanguage;
 import com.cotato.kampus.domain.user.enums.UserRole;
 
 import lombok.Builder;
@@ -69,6 +70,7 @@ public class OAuth2Attribute {
 			.username(username)
 			.nickname("nickname")
 			.nationality(Nationality.OTHER)
+			.preferredLanguage(PreferredLanguage.ENGLISH_AMERICAN)
 			.userRole(UserRole.UNVERIFIED)
 			.build();
 	}

--- a/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
+++ b/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
 	//User
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.", "USER-001"),
 	USER_UNVERIFIED(HttpStatus.NOT_FOUND, "학생 인증되지 않은 유저입니다.", "USER-002"),
+	USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다.", "USER-003"),
 
 	//Board
 	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시판을 찾을 수 없습니다.", "BOARD-001"),

--- a/src/main/java/com/cotato/kampus/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cotato/kampus/global/error/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.cotato.kampus.global.error.handler;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -67,5 +68,17 @@ public class GlobalExceptionHandler {
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.BAD_REQUEST, request);
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(errorResponse);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e,
+		HttpServletRequest request) {
+		String errorMessage = e.getBindingResult().getFieldErrors().stream()
+			.findFirst()
+			.map(error -> error.getField() + ": " + error.getDefaultMessage())
+			.orElse("잘못된 요청입니다.");
+
+		ErrorResponse errorResponse = ErrorResponse.of(request, ErrorCode.INVALID_PARAMETER, errorMessage);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
 	}
 }


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
카카오 소셜 로그인 후 회원 정보 수정 API 구현
- 닉네임 검증 기능 구현
### 상세 내용(Describe your changes)
#### 성공
<img width="609" alt="Screenshot 2025-01-30 at 7 38 42 PM" src="https://github.com/user-attachments/assets/657aca88-ec16-4505-b298-2ae2768d23ec" />

```
{
  "status": "OK",
  "data": {
    "userId": 1
  },
  "timestamp": "2025-01-30 19:38:31"
}
```

#### 실패
- request
```
{
  "nickname": "동영",
  "nationality": "KOREA",
  "preferredLanguage": "KOREAN"
}
```

 - response
```
{
  "code": "COMMON-002",
  "message": "nickname: 닉네임은 5~20자의 영어 소문자(a-z)만 입력 가능합니다.",
  "method": "PATCH",
  "requestURI": "/v1/api/users/details"
}
```

- 중복 닉네임 검증

```
{
  "code": "USER-003",
  "message": "이미 존재하는 닉네임입니다.",
  "method": "PATCH",
  "requestURI": "/v1/api/users/details"
}
```

- 국적 입력 안 됐을 경우
```
{
  "code": "COMMON-002",
  "message": "nationality: 국적을 입력해야 합니다.",
  "method": "PATCH",
  "requestURI": "/v1/api/users/details"
}
```
- 선호 언어 입력 안 됐을 경우
```
{
  "code": "COMMON-002",
  "message": "preferredLanguage: 선호 언어를 입력해야 합니다.",
  "method": "PATCH",
  "requestURI": "/v1/api/users/details"
}
```
### Issue Number or Link
resolved #63 