### PR TITLE
[FEATURE] 유저정보 조회시 유저 상태 필드 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/user/dto/UserDetailsDto.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dto/UserDetailsDto.java
@@ -3,19 +3,22 @@ package com.cotato.kampus.domain.user.dto;
 import com.cotato.kampus.domain.user.domain.User;
 import com.cotato.kampus.domain.user.enums.Nationality;
 import com.cotato.kampus.domain.user.enums.PreferredLanguage;
+import com.cotato.kampus.domain.user.enums.UserStatus;
 
 public record UserDetailsDto(
 	Long id,
 	String nickname,
 	Nationality nationality,
-	PreferredLanguage preferredLanguage
+	PreferredLanguage preferredLanguage,
+	UserStatus userStatus
 ) {
 	public static UserDetailsDto from(User user) {
 		return new UserDetailsDto(
 			user.getId(),
 			user.getNickname(),
 			user.getNationality(),
-			user.getPreferredLanguage()
+			user.getPreferredLanguage(),
+			user.getUserStatus()
 		);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/user/dto/response/UserDetailsResponse.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dto/response/UserDetailsResponse.java
@@ -3,19 +3,22 @@ package com.cotato.kampus.domain.user.dto.response;
 import com.cotato.kampus.domain.user.dto.UserDetailsDto;
 import com.cotato.kampus.domain.user.enums.Nationality;
 import com.cotato.kampus.domain.user.enums.PreferredLanguage;
+import com.cotato.kampus.domain.user.enums.UserStatus;
 
 public record UserDetailsResponse(
 	Long id,
 	String nickname,
 	Nationality nationality,
-	PreferredLanguage preferredLanguage
+	PreferredLanguage preferredLanguage,
+	boolean needSetup
 ) {
 	public static UserDetailsResponse from(UserDetailsDto userDetails) {
 		return new UserDetailsResponse(
 			userDetails.id(),
 			userDetails.nickname(),
 			userDetails.nationality(),
-			userDetails.preferredLanguage()
+			userDetails.preferredLanguage(),
+			userDetails.userStatus().equals(UserStatus.PENDING_DETAILS)
 		);
 	}
 }

--- a/src/main/java/com/cotato/kampus/global/auth/oauth/handler/OAuthSuccessHandler.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/handler/OAuthSuccessHandler.java
@@ -10,7 +10,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import com.cotato.kampus.domain.auth.application.RefreshService;
-import com.cotato.kampus.domain.user.enums.UserStatus;
 import com.cotato.kampus.global.auth.oauth.service.dto.CustomOAuth2User;
 import com.cotato.kampus.global.util.JwtUtil;
 
@@ -52,7 +51,6 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 		String uniqueId = customOAuth2User.getUniqueId();
 		String username = customOAuth2User.getName();
-		UserStatus userStatus = customOAuth2User.getUserStatus();
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
 		GrantedAuthority auth = iterator.next();
@@ -70,13 +68,9 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 		response.setHeader(ACCESS_HEADER_NAME, TOKEN_PREFIX + access);
 		response.setHeader(REFRESH_HEADER_NAME, TOKEN_PREFIX + refresh);
 
-		boolean needSetup = userStatus == UserStatus.PENDING_DETAILS;
-
 		// 로컬 환경에서 개발할 때는 로컬로 리다이렉트 되도록 설정(추후 삭제 예정)
 		String finalRedirectUrl = isDevelopment(request) ? DEV_REDIRECT_URL : REDIRECT_URL;
 		log.info("Redirect URL: {}", finalRedirectUrl);
-		response.sendRedirect(finalRedirectUrl + "?accessToken=" + access
-			+ "&refreshToken=" + refresh
-			+ "&needSetup=" + needSetup);
+		response.sendRedirect(finalRedirectUrl + "?accessToken=" + access + "&refreshToken=" + refresh);
 	}
 }

--- a/src/main/java/com/cotato/kampus/global/auth/oauth/service/dto/CustomOAuth2User.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/service/dto/CustomOAuth2User.java
@@ -7,8 +7,6 @@ import java.util.Map;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
-import com.cotato.kampus.domain.user.enums.UserStatus;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -43,9 +41,5 @@ public class CustomOAuth2User implements OAuth2User {
 	@Override
 	public String getName() {
 		return OAuthUserRequest.getUsername();
-	}
-
-	public UserStatus getUserStatus() {
-		return OAuthUserRequest.getUserStatus();
 	}
 }


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
로그인 성공후 리다이렉트 url에 needSetup 표시하는 기능 제거
유저 정보 조회시 needSetup 필드를 통해 추가 설정이 필요한지 여부 판단하도록 추가

### 상세 내용(Describe your changes)
<img width="741" alt="Screenshot 2025-02-10 at 7 49 35 PM" src="https://github.com/user-attachments/assets/fb06379b-289d-433a-b13b-5ace92751ac4" />

```
{
  "status": "OK",
  "data": {
    "id": 1,
    "nickname": "nickname",
    "nationality": "KOREA",
    "preferredLanguage": "KOREAN",
    "needSetup": true
  },
  "timestamp": "2025-02-10 19:49:19"
}
```

<img width="759" alt="Screenshot 2025-02-10 at 7 50 59 PM" src="https://github.com/user-attachments/assets/b0c88e77-b31d-43e8-8696-0d79af8882bc" />

```
{
  "status": "OK",
  "data": {
    "userId": 1
  },
  "timestamp": "2025-02-10 19:50:22"
}
```

이후 유저 정보 조회시
```
{
  "status": "OK",
  "data": {
    "id": 1,
    "nickname": "dhktgphkzuicfge",
    "nationality": "KOREA",
    "preferredLanguage": "KOREAN",
    "needSetup": false
  },
  "timestamp": "2025-02-10 19:51:29"
}
```
### Issue Number or Link
resolved #74