### PR TITLE
[FIX] 채팅방 정보 상세 조회 버그 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/chat/application/PostChatService.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/application/PostChatService.java
@@ -21,6 +21,7 @@ import com.cotato.kampus.domain.chat.dto.ChatRoomPreviewList;
 import com.cotato.kampus.domain.common.application.ApiUserResolver;
 import com.cotato.kampus.domain.post.application.PostFinder;
 import com.cotato.kampus.domain.post.dto.PostDto;
+import com.cotato.kampus.domain.post.dto.PostReferenceDto;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -103,14 +104,16 @@ public class PostChatService {
 	public ChatRoomDetailDto getChatRoomDetail(Long chatroomId) {
 		// 1. Find chatroom
 		Chatroom chatroom = chatRoomFinder.findChatroom(chatroomId);
+		// 2. 게시글 정보 가져옴
+		PostReferenceDto postReference = postFinder.findPostReference(chatroom.getPostId());
 
-		// 2. Find associated post
-		PostDto postDto = postFinder.findPost(chatroom.getPostId());
-
-		// 3. Find board information
-		BoardDto board = boardFinder.findBoardDto(postDto.boardId());
-
-		return ChatRoomDetailDto.of(chatroom, postDto, board);
+		// 3. 게시글이 삭제된 경우
+		if (postReference.isDeleted()) {
+			return ChatRoomDetailDto.ofDeleted(chatroom, postReference);
+		}
+		// 4. 게시글이 존재하는 경우
+		BoardDto board = boardFinder.findBoardDto(postReference.boardId());
+		return ChatRoomDetailDto.of(chatroom, postReference, board);
 	}
 
 	@Transactional

--- a/src/main/java/com/cotato/kampus/domain/chat/dto/ChatRoomDetailDto.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/dto/ChatRoomDetailDto.java
@@ -2,22 +2,36 @@ package com.cotato.kampus.domain.chat.dto;
 
 import com.cotato.kampus.domain.board.dto.BoardDto;
 import com.cotato.kampus.domain.chat.domain.Chatroom;
-import com.cotato.kampus.domain.post.dto.PostDto;
+import com.cotato.kampus.domain.post.dto.PostReferenceDto;
 
 public record ChatRoomDetailDto(
 	Long chatroomId,
 	Long postId,
 	String postTitle,
+	Long boardId,
 	String boardName,
 	Long initialSenderId,
 	Long initialReceiverId
 ) {
-	public static ChatRoomDetailDto of(Chatroom chatroom, PostDto post, BoardDto board) {
+	public static ChatRoomDetailDto of(Chatroom chatroom, PostReferenceDto post, BoardDto board) {
 		return new ChatRoomDetailDto(
 			chatroom.getId(),
-			post.id(),
+			post.postId(),
 			post.title(),
+			board.boardId(),
 			board.boardName(),
+			chatroom.getInitialSenderId(),
+			chatroom.getInitialReceiverId()
+		);
+	}
+
+	public static ChatRoomDetailDto ofDeleted(Chatroom chatroom, PostReferenceDto post) {
+		return new ChatRoomDetailDto(
+			chatroom.getId(),
+			post.postId(),
+			post.title(),
+			-1L,
+			"[삭제된 게시판]",
 			chatroom.getInitialSenderId(),
 			chatroom.getInitialReceiverId()
 		);

--- a/src/main/java/com/cotato/kampus/domain/chat/dto/ChatRoomDetailDto.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/dto/ChatRoomDetailDto.java
@@ -31,7 +31,7 @@ public record ChatRoomDetailDto(
 			post.postId(),
 			post.title(),
 			-1L,
-			"[삭제된 게시판]",
+			"",
 			chatroom.getInitialSenderId(),
 			chatroom.getInitialReceiverId()
 		);

--- a/src/main/java/com/cotato/kampus/domain/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/dto/response/ChatRoomDetailResponse.java
@@ -6,18 +6,22 @@ public record ChatRoomDetailResponse(
 	Long chatroomId,
 	Long postId,
 	String postTitle,
+	Long boardId,
 	String boardName,
 	Long initialSenderId,
-	Long initialReceiverId
+	Long initialReceiverId,
+	boolean isPostDeleted
 ) {
 	public static ChatRoomDetailResponse from(ChatRoomDetailDto dto) {
 		return new ChatRoomDetailResponse(
 			dto.chatroomId(),
 			dto.postId(),
 			dto.postTitle(),
+			dto.boardId(),
 			dto.boardName(),
 			dto.initialSenderId(),
-			dto.initialReceiverId()
+			dto.initialReceiverId(),
+			dto.postId() == -1L
 		);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/post/application/PostFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/post/application/PostFinder.java
@@ -25,9 +25,10 @@ import com.cotato.kampus.domain.post.dto.MyPostWithPhoto;
 import com.cotato.kampus.domain.post.dto.PostDraftDto;
 import com.cotato.kampus.domain.post.dto.PostDraftWithPhoto;
 import com.cotato.kampus.domain.post.dto.PostDto;
+import com.cotato.kampus.domain.post.dto.PostReferenceDto;
 import com.cotato.kampus.domain.post.dto.PostWithPhotos;
-import com.cotato.kampus.domain.post.enums.PostSortType;
 import com.cotato.kampus.domain.post.dto.SearchedPost;
+import com.cotato.kampus.domain.post.enums.PostSortType;
 import com.cotato.kampus.global.common.dto.CustomPageRequest;
 import com.cotato.kampus.global.error.ErrorCode;
 import com.cotato.kampus.global.error.exception.AppException;
@@ -91,10 +92,10 @@ public class PostFinder {
 		};
 	}
 
-	public Slice<PostWithPhotos> findUserCommentedPosts(List<Long> postIds, int page){
+	public Slice<PostWithPhotos> findUserCommentedPosts(List<Long> postIds, int page) {
 
 		// CustomPageRequest customPageRequest = new CustomPageRequest(page, PAGE_SIZE, Sort.Direction.DESC);
-		PageRequest pageRequest = PageRequest.of(page-1, PAGE_SIZE);
+		PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
 		String orderList = postIds.stream().map(String::valueOf).collect(Collectors.joining(","));
 		Slice<Post> posts = postRepository.findPostsByIdsInOrder(postIds, orderList, pageRequest);
 
@@ -112,6 +113,12 @@ public class PostFinder {
 			.orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND));
 
 		return PostDto.from(post);
+	}
+
+	public PostReferenceDto findPostReference(Long postId) {
+		return postRepository.findById(postId)
+			.map(PostReferenceDto::from)
+			.orElse(PostReferenceDto.deleted());
 	}
 
 	public Slice<MyPostWithPhoto> findUserPosts(int page) {
@@ -219,5 +226,4 @@ public class PostFinder {
 			return SearchedPost.of(post, boardName, postPhoto);
 		});
 	}
-
 }

--- a/src/main/java/com/cotato/kampus/domain/post/dto/PostReferenceDto.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dto/PostReferenceDto.java
@@ -1,0 +1,23 @@
+package com.cotato.kampus.domain.post.dto;
+
+import com.cotato.kampus.domain.post.domain.Post;
+
+public record PostReferenceDto(
+	Long postId,
+	String title,
+	Long boardId,
+	boolean isDeleted
+) {
+	public static PostReferenceDto from(Post post) {
+		return new PostReferenceDto(
+			post.getId(),
+			post.getTitle(),
+			post.getBoardId(),
+			false
+		);
+	}
+
+	public static PostReferenceDto deleted() {
+		return new PostReferenceDto(-1L, "[삭제된 게시글]", -1L, true);
+	}
+}

--- a/src/main/java/com/cotato/kampus/domain/post/dto/PostReferenceDto.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dto/PostReferenceDto.java
@@ -18,6 +18,6 @@ public record PostReferenceDto(
 	}
 
 	public static PostReferenceDto deleted() {
-		return new PostReferenceDto(-1L, "[삭제된 게시글]", -1L, true);
+		return new PostReferenceDto(-1L, "", -1L, true);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/user/dto/request/NicknameCheckRequest.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dto/request/NicknameCheckRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Pattern;
 
 public record NicknameCheckRequest(
 	@NotBlank(message = "닉네임을 입력해주세요.")
-	@Pattern(regexp = "^[a-z]{5,20}$", message = "닉네임은 5~20자의 영어 소문자(a-z)만 입력 가능합니다.")
+	@Pattern(regexp = "^[a-z0-9]{5,20}$", message = "닉네임은 5~20자의 영어 소문자(a-z)와 숫자(0-9)만 입력 가능합니다.")
 	String nickname
 ) {
 }

--- a/src/main/java/com/cotato/kampus/domain/user/dto/request/UserDetailsUpdateRequest.java
+++ b/src/main/java/com/cotato/kampus/domain/user/dto/request/UserDetailsUpdateRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Pattern;
 
 public record UserDetailsUpdateRequest(
 	@NotBlank
-	@Pattern(regexp = "^[a-z]{5,20}$", message = "닉네임은 5~20자의 영어 소문자(a-z)만 입력 가능합니다.")
+	@Pattern(regexp = "^[a-z0-9]{5,20}$", message = "닉네임은 5~20자의 영어 소문자(a-z)와 숫자(0-9)만 입력 가능합니다.")
 	String nickname,
 
 	@NotNull(message = "국적을 입력해야 합니다.")


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
채팅방 조회시 삭제된 게시글인 경우에도 정보가 조회되어야 하는데 삭제된 게시글인 경우 에러가 발생

### 상세 내용(Describe your changes)
<img width="792" alt="Screenshot 2025-02-19 at 8 36 21 PM" src="https://github.com/user-attachments/assets/28bc1c5f-34b7-4fd9-bf4c-f82fc26f585a" />

삭제되지 않은 경우
```
{
  "status": "OK",
  "data": {
    "chatroomId": 4,
    "postId": 8,
    "postTitle": "string",
    "boardId": 1,
    "boardName": "board1",
    "initialSenderId": 2,
    "initialReceiverId": 1,
    "isPostDeleted": false
  },
  "timestamp": "2025-02-19 20:37:32"
}
```

삭제된 경우
```
{
  "status": "OK",
  "data": {
    "chatroomId": 2,
    "postId": -1,
    "postTitle": "[삭제된 게시글]",
    "boardId": -1,
    "boardName": "[삭제된 게시판]",
    "initialSenderId": 2,
    "initialReceiverId": 1,
    "isPostDeleted": true
  },
  "timestamp": "2025-02-19 20:36:44"
}
```

유저 닉네임 제약조건 수정
- 숫자도 허용
```
{
  "status": "OK",
  "data": {
    "isAvailable": true
  },
  "timestamp": "2025-02-19 20:38:23"
}
```
### Issue Number or Link
resolved #102 