### PR TITLE
[BUGFIX] 게시글 작성자와 댓글 작성자가 동일한 경우"Author" 로 반환되도록 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
+++ b/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
@@ -83,10 +83,10 @@ public class BoardService {
 
 	public BoardDto getUniversityBoard() {
 		// 유저 조회
-		Long userId = apiUserResolver.getCurrentUserId();
+		UserDto userDto = apiUserResolver.getCurrentUserDto();
 
 		// 재학생 인증 확인
-		Long userUniversityId = userValidator.validateStudentVerification(userId);
+		Long userUniversityId = userValidator.validateStudentVerification(userDto);
 
 		// 대학교 게시판 조회
 		return boardFinder.findUserUniversityBoard(userUniversityId);

--- a/src/main/java/com/cotato/kampus/domain/user/application/UserValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/user/application/UserValidator.java
@@ -22,13 +22,12 @@ public class UserValidator {
 	private final UserFinder userFinder;
 
 	// 재학생 인증 후 universityId 반환
-	public Long validateStudentVerification(Long userId) {
-		User user = userFinder.findById(userId);
+	public Long validateStudentVerification(UserDto userDto) {
 
-		if (user.getUserRole() == UserRole.UNVERIFIED)
+		if (userDto.userRole() == UserRole.UNVERIFIED)
 			throw new AppException(ErrorCode.USER_UNVERIFIED);
 
-		return user.getUniversityId();
+		return userDto.universityId();
 	}
 
 	// 재학생 인증 중복 요청 검증


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
게시글 작성자가 댓글 작성 시, 게시글의 AnonymousNumber가 증가되지 않도록 수정
게시글의 댓글 목록 조회 시, 작성자의 댓글은 author 필드 값이 "Author"로 반환되도록 수정
 
### 상세 내용(Describe your changes)

```
{
    "status": "OK",
    "data": {
        "comments": [
            {
                "commentId": 47,
                "parentId": null,
                "commentStatus": "NORMAL",
                "author": "Anonymous1",
                "content": "작성자 아님",
                "likes": 0,
                "isLiked": false,
                "createdTime": "2025-02-21T10:27:21.077333",
                "replies": []
            },
            {
                "commentId": 48,
                "parentId": null,
                "commentStatus": "NORMAL",
                "author": "Author",
                "content": "작성자 등장",
                "likes": 0,
                "isLiked": false,
                "createdTime": "2025-02-21T10:40:18.570023",
                "replies": []
            }
        ]
    },
    "timestamp": "2025-02-21 10:40:21"
}
```

### Issue Number or Link
