### PR TITLE
[BUGFIX] ChatRoomValidator 클래스의 타입 불일치 버그 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/ChatRoomValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/ChatRoomValidator.java
@@ -39,6 +39,6 @@ public class ChatRoomValidator {
 	// 채팅방에 들어가있지 않은 유저가 조회하는 경우
 	public void validateUser(Long userId, Long chatroomId) {
 		ChatRoom chatRoom = chatRoomFinder.findByChatRoomId(chatroomId);
-		chatRoom.validateUser(userId);
+		chatRoom.validateUser(userId, chatroomId);
 	}
 }


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)


### 상세 내용(Describe your changes)
ChatRoomValidator에서 ChatRoom 클래스의 validateUser 메서드 호출하는 부분에 chatroomId 파라미터 누락된 부분 수정했습니다. (배포 실패 되어있었음)

### Issue Number or Link
