### PR TITLE
[REFACTOR] 토큰 검증 관련 예외처리

### DIFF
--- a/src/main/java/com/cotato/kampus/global/auth/nativeapp/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cotato/kampus/global/auth/nativeapp/filter/JwtAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
 		log.info("Token extracted from header: {}", token);
 
 		// 토큰 검증
-		validateToken(token);
+		jwtUtil.validateToken(token);
 
 		// 사용자 정보 추출 및 인증 객체 생성
 		AppUserDetailsRequest detailsRequest = createPrincipalDetailsRequest(token);
@@ -74,12 +74,6 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
 			throw new JwtException(ErrorCode.TOKEN_NOT_FOUND);
 		}
 		return authorizationHeader.substring(7).trim(); // Bearer 제거
-	}
-
-	private void validateToken(String token) {
-		if (jwtUtil.isExpired(token)) {
-			throw new JwtException(ErrorCode.TOKEN_EXPIRED);
-		}
 	}
 
 	private AppUserDetailsRequest createPrincipalDetailsRequest(String token) {

--- a/src/main/java/com/cotato/kampus/global/config/WebSocketConfig.java
+++ b/src/main/java/com/cotato/kampus/global/config/WebSocketConfig.java
@@ -81,7 +81,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 					String authHeader = accessor.getFirstNativeHeader("Authorization");
 
 					String token = extractToken(authHeader);
-					validateToken(token);
+
+					jwtUtil.validateToken(token);
 
 					// 사용자 정보 추출 및 인증 객체 생성
 					AppUserDetailsRequest detailsRequest = createPrincipalDetailsRequest(token);
@@ -107,12 +108,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 			throw new JwtException(ErrorCode.TOKEN_NOT_FOUND);
 		}
 		return authorizationHeader.substring(7).trim(); // Bearer 제거
-	}
-
-	private void validateToken(String token) {
-		if (jwtUtil.isExpired(token)) {
-			throw new JwtException(ErrorCode.TOKEN_EXPIRED);
-		}
 	}
 
 	private AppUserDetailsRequest createPrincipalDetailsRequest(String token) {

--- a/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
+++ b/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
@@ -133,8 +133,8 @@ public enum ErrorCode {
 	//JWT
 	TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "헤더에 Access Token을 찾을 수 없습니다.", "JWT-001"),
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료 되었습니다.", "JWT-002"),
-	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "올바른 형식의 토큰이 아닙니다.", "JWT-003"),
-	MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "토큰 내부에 공백이 있습니다.", "JWT-004"),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.", "JWT-003"),
+	MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "토큰 형식에 문제가 있습니다.", "JWT-004"),
 
 	// DeepL
 	INVALID_DEEPL_AUTH_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "DeepL 인증키가 유효하지 않습니다.", "DEEPL-001"),

--- a/src/main/java/com/cotato/kampus/global/util/JwtUtil.java
+++ b/src/main/java/com/cotato/kampus/global/util/JwtUtil.java
@@ -9,7 +9,12 @@ import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.JwtException;
+
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 
 @Component
 public class JwtUtil {
@@ -61,15 +66,19 @@ public class JwtUtil {
 			.get("category", String.class);
 	}
 
-	public Boolean isExpired(String token) {
-
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.getExpiration()
-			.before(new Date());
+	public void validateToken(String token) {
+		try {
+			Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token);
+		} catch (ExpiredJwtException e) {
+			throw new JwtException(ErrorCode.TOKEN_EXPIRED);
+		} catch (MalformedJwtException e) {
+			throw new JwtException(ErrorCode.MALFORMED_TOKEN);
+		} catch (Exception e) {
+			throw new JwtException(ErrorCode.INVALID_TOKEN);
+		}
 	}
 
 	public String createJwt(String category, String uniqueId, String username, String role, Long expiredMs) {

--- a/src/test/java/com/cotato/kampus/global/util/JwtUtilTest.java
+++ b/src/test/java/com/cotato/kampus/global/util/JwtUtilTest.java
@@ -1,0 +1,69 @@
+package com.cotato.kampus.global.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.JwtException;
+
+@ExtendWith(MockitoExtension.class)
+class JwtUtilTest {
+
+	private JwtUtil jwtUtil;
+	private final String SECRET_KEY = "testSecretKeyForJwtUtilTestMustBeAtLeast32BytesLong";
+	private final String CATEGORY = "test";
+	private final String UNIQUE_ID = "testUniqueId";
+	private final String USERNAME = "testUser";
+	private final String ROLE = "USER";
+
+	@BeforeEach
+	void setUp() {
+		jwtUtil = new JwtUtil(SECRET_KEY);
+	}
+
+	@Test
+	@DisplayName("토큰 검증 성공: 유효한 토큰이 주어졌을 때 예외 없이 처리되어야 한다")
+	void isExpired_withValidToken_shouldReturnFalse() {
+		// given
+		long validExpirationMs = 3600000L; // 1시간
+		String validToken = jwtUtil.createJwt(CATEGORY, UNIQUE_ID, USERNAME, ROLE, validExpirationMs);
+
+		// when
+		// then
+		Assertions.assertThatCode(() -> jwtUtil.validateToken(validToken))
+			.doesNotThrowAnyException();
+
+	}
+
+	@Test
+	@DisplayName("토큰 검증 실패: 만료된 토큰이 주어졌을 때 예외 발생")
+	void isExpired_withExpiredToken_shouldReturnTrue() {
+		// given
+		long expiredExpirationMs = -1000L; // 만료된 토큰 생성을 위해 음수값 사용
+		String expiredToken = jwtUtil.createJwt(CATEGORY, UNIQUE_ID, USERNAME, ROLE, expiredExpirationMs);
+
+		// when
+		assertThatThrownBy(() -> jwtUtil.validateToken(expiredToken))
+			.isInstanceOf(JwtException.class)
+			.hasMessage(ErrorCode.TOKEN_EXPIRED.getMessage());
+	}
+
+	@Test
+	@DisplayName("토큰 검증 실패: 잘못된 형식의 토큰이 주어졌을 때 예외 발생")
+	void isExpired_withInvalidToken_shouldHandleExceptionAndReturnTrue() {
+		// given
+		String invalidToken = "invalid.jwt.token";
+
+		// when
+		// then
+		assertThatThrownBy(() -> jwtUtil.validateToken(invalidToken))
+			.isInstanceOf(JwtException.class)
+			.hasMessage(ErrorCode.MALFORMED_TOKEN.getMessage());
+	}
+}


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
토큰 검증하는 로직 예외처리 변경
테스트 작성
### 상세 내용(Describe your changes)

토큰이 만료된 경우 예외처리 로직에 문제가 있어 수정
```
Jwts.parser()
  .verifyWith(secretKey)
  .build()
  .parseSignedClaims(token)
  .getPayload()
  .getExpiration()
  .before(new Date());
```
[변경 전]
위 로직에서 토큰이 만료된 경우 `parseSignedClains(token)`에서 ExpiredJwtException이 발생하여 before까지 도달하지 못하고 알 수 없는 예외가 발생하였음

[변경 후]
try - catch를 통해 발생하는 예외를 잡아 JwtException(커스텀 예외, 원래 있던 예외)를 던지도록 구성

### Issue Number or Link
resolved #214 