### PR TITLE
[BUGFIX] PostDetails 생성 시 boardName에 title이 잘못 매핑되는 문제 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/post/domain/PostDetails.java
+++ b/src/main/java/com/cotato/kampus/domain/post/domain/PostDetails.java
@@ -34,9 +34,9 @@ public record PostDetails(
 		return new PostDetails(
 			post.getId(),
 			post.getBoardId(),
+			boardName,
 			post.getTitle(),
 			post.getContent(),
-			boardName,
 			post.getLikeCount(),
 			post.getScrapCount(),
 			post.getCommentCount(),


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
PostDetails.of 파라미터 순서 변경

### 상세 내용(Describe your changes)


### Issue Number or Link
Resolve #227 