### PR TITLE
[REFACTOR] 게시판 생성 시 CARDNEWS, TRENDING 중복 생성 예외 구현

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
+++ b/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
@@ -95,8 +95,9 @@ public class AdminService {
 		// 관리자 검증
 		userValidator.validateAdminAccess();
 
-		// 게시판 이름 중복 검사
+		// 게시판 이름/타입 유효성 검사
 		boardValidator.validateUniqueName(boardName);
+		boardValidator.validateUniqueType(boardType);
 
 		Long universityId = null;
 		if (universityCode != null) {

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -28,4 +28,5 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 
 	List<BoardEntity> findAllByBoardStatus(BoardStatus boardStatus);
 
+	boolean existsByBoardType(BoardType boardType);
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
@@ -99,4 +99,9 @@ public class BoardRepositoryImpl implements BoardRepository {
 			.map(BoardEntity::toDomain)
 			.toList();
 	}
+
+	@Override
+	public boolean existsByBoardType(BoardType boardType) {
+		return boardJpaRepository.existsByBoardType(boardType);
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardValidator.java
@@ -80,4 +80,12 @@ public class BoardValidator {
 			throw new AppException(ErrorCode.INVALID_BOARD_TYPE);
 		}
 	}
+
+	public void validateUniqueType(BoardType boardType) {
+		if(boardType == BoardType.CARDNEWS || boardType == BoardType.TRENDING) {
+			if(boardRepository.existsByBoardType(boardType)) {
+				throw new AppException(ErrorCode.DUPLICATED_UNIQUE_BOARD_TYPE);
+			}
+		}
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
@@ -33,4 +33,6 @@ public interface BoardRepository{
 	List<Board> findByDeletionScheduledAtBefore(LocalDateTime now);
 
 	List<Board> findAllByBoardStatus(BoardStatus boardStatus);
+
+	boolean existsByBoardType(BoardType boardType);
 }

--- a/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
+++ b/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
@@ -121,6 +121,7 @@ public enum ErrorCode {
 	INVALID_BOARD_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 BoardType 입니다.", "BOARD-011"),
 	BOARD_NOT_ACTIVE(HttpStatus.FORBIDDEN, "게시판이 활성화되지 않았습니다.", "BOARD-012"),
 	BOARD_UNIVERSITY_ID_REQUIRED(HttpStatus.BAD_REQUEST, "대학 게시판은 대학 ID가 필수입니다.", "BOARD-013"),
+	DUPLICATED_UNIQUE_BOARD_TYPE(HttpStatus.BAD_REQUEST, "중복 생성이 허용되지 않는 게시판 타입입니다.", "BOARD-014"),
 
 	// Product
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다.", "PRODUCT-001"),

--- a/src/test/java/com/cotato/kampus/domain/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/admin/application/AdminServiceTest.java
@@ -1,94 +1,63 @@
-// package com.cotato.kampus.domain.admin.application;
-//
-// import static org.junit.jupiter.api.Assertions.*;
-// import static org.mockito.Mockito.*;
-//
-// import java.util.List;
-//
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.extension.ExtendWith;
-// import org.mockito.InjectMocks;
-// import org.mockito.Mock;
-// import org.mockito.junit.jupiter.MockitoExtension;
-//
-// import com.cotato.kampus.domain.board.implement.board.BoardAppender;
-// import com.cotato.kampus.domain.board.implement.board.BoardValidator;
-// import com.cotato.kampus.domain.board.implement.boardCategory.BoardCategoryAppender;
-// import com.cotato.kampus.domain.university.application.UnivFinder;
-// import com.cotato.kampus.domain.user.application.UserValidator;
-//
-// @ExtendWith(MockitoExtension.class)
-// class AdminServiceTest {
-//
-// 	@Mock
-// 	private UserValidator userValidator;
-//
-// 	@Mock
-// 	private BoardValidator boardValidator;
-//
-// 	@Mock
-// 	private UnivFinder univFinder;
-//
-// 	@Mock
-// 	private BoardAppender boardAppender;
-//
-// 	@Mock
-// 	private BoardCategoryAppender boardCategoryAppender;
-//
-// 	@InjectMocks
-// 	private AdminService adminService;
-//
-// 	@Test
-// 	@DisplayName("일반 게시판을 카테고리와 함께 생성")
-// 	void createGeneralBoardWithCategories() {
-// 		// Arrange
-// 		String boardName = "자유게시판";
-// 		String description = "자유롭게 대화를 나눌 수 있는 게시판입니다.";
-// 		String universityCode = null;
-// 		List<String> categories = List.of("일상", "질문", "정보");
-//
-// 		Long expectedBoardId = 1L;
-// 		when(boardAppender.appendBoard(boardName,description, null, true))
-// 			.thenReturn(1L);
-//
-// 		// Act
-// 		Long boardId = adminService.createBoard(boardName, description, universityCode, categories);
-//
-// 		// Assert
-// 		assertEquals(expectedBoardId, boardId);
-// 		verify(userValidator).validateAdminAccess();
-// 		verify(boardValidator).validateUniqueName(boardName);
-// 		verify(boardAppender).appendBoard(boardName, description, null, true);
-// 		verify(boardCategoryAppender).appendCategories(expectedBoardId, categories);
-// 	}
-//
-// 	@Test
-// 	@DisplayName("학교 게시판을 카테고리 없이 생성")
-// 	void createUniversityBoardWithoutCategories() {
-// 		// Arrange
-// 		String boardName = "학교 공지사항";
-// 		String description = "학교 공지사항을 확인하세요.";
-// 		String universityCode = "Hongik University";
-// 		List<String> categories = List.of();
-//
-// 		Long universityId = 401L;
-// 		Long expectedBoardId = 1L;
-//
-// 		when(univFinder.findIdByCode(universityCode)).thenReturn(universityId);
-// 		when(boardAppender.appendBoard(boardName, description, universityId, false))
-// 			.thenReturn(expectedBoardId);
-//
-// 		// Act
-// 		Long boardId = adminService.createBoard(boardName, description, universityCode, categories);
-//
-// 		// Assert
-// 		assertEquals(expectedBoardId, boardId);
-// 		verify(userValidator).validateAdminAccess();
-// 		verify(boardValidator).validateUniqueName(boardName);
-// 		verify(univFinder).findIdByCode(universityCode);
-// 		verify(boardValidator).validateUniversityBoardExists(universityId);
-// 		verify(boardAppender).appendBoard(boardName, description, universityId, false);
-// 		verify(boardCategoryAppender).appendCategories(expectedBoardId, categories);
-// 	}
-// }
+package com.cotato.kampus.domain.admin.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.kampus.domain.board.domain.NormalBoard;
+import com.cotato.kampus.domain.board.enums.BoardStatus;
+import com.cotato.kampus.domain.board.enums.BoardType;
+import com.cotato.kampus.domain.board.implement.port.BoardRepository;
+import com.cotato.kampus.domain.user.application.UserValidator;
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.AppException;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class AdminServiceTest {
+
+	@Autowired
+	private AdminService adminService;
+
+	@MockBean
+	private UserValidator userValidator;
+
+	@Autowired
+	private BoardRepository boardRepository;
+
+	@Test
+	@DisplayName("게시판 생성 테스트 - CARDNEWS 타입 중복 생성 예외")
+	void createBoard_duplicateUniqueType_CARDNEWS() {
+		// Given
+		doNothing().when(userValidator).validateAdminAccess();
+		boardRepository.save(NormalBoard.create("카드뉴스 게시판1", "카드뉴스 게시판입니다,", false, BoardStatus.ACTIVE, BoardType.CARDNEWS));
+
+		// When&Then
+		assertThatThrownBy(() -> adminService.createBoard("카드뉴스 게시판2", "두 번쨰 카드뉴스 게시판입니다.", BoardType.CARDNEWS, null, List.of()))
+			.isInstanceOf(AppException.class)
+			.hasMessage(ErrorCode.DUPLICATED_UNIQUE_BOARD_TYPE.getMessage());
+	}
+
+	@Test
+	@DisplayName("게시판 생성 테스트 - TRENDING 타입 중복 생성 예외")
+	void createBoard_duplicateUniqueType_TRENDING() {
+		// Given
+		doNothing().when(userValidator).validateAdminAccess();
+		boardRepository.save(NormalBoard.create("트렌딩 게시판1", "트렌딩 게시판입니다,", false, BoardStatus.ACTIVE, BoardType.TRENDING));
+
+		// When&Then
+		assertThatThrownBy(() -> adminService.createBoard("트렌딩 게시판2", "두 번쨰 트렌딩 게시판입니다.", BoardType.TRENDING, null, List.of()))
+			.isInstanceOf(AppException.class)
+			.hasMessage(ErrorCode.DUPLICATED_UNIQUE_BOARD_TYPE.getMessage());
+	}
+}


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)

CARDNEWS, TRENDING 타입의 게시판은 중복 생성 불가하도록 예외 처리

테스트 코드 작성
- 게시판 생성 실패: 카드뉴스 게시판이 이미 있는 경우
- 게시판 생성 실패: 트렌딩 게시판이 이미 있는 경우

API 예외 목록 노션 반영 완료
`DUPLICATED_UNIQUE_BOARD_TYPE(HttpStatus.BAD_REQUEST, "중복 생성이 허용되지 않는 게시판 타입입니다.", "BOARD-014")`

### 상세 내용(Describe your changes)


### Issue Number or Link
Resolve #255 