### PR TITLE
[FEATURE] 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/auth/api/AuthController.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/api/AuthController.java
@@ -1,5 +1,7 @@
 package com.cotato.kampus.domain.auth.api;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.cotato.kampus.domain.auth.application.AuthService;
+import com.cotato.kampus.domain.auth.application.RefreshService;
+import com.cotato.kampus.domain.auth.domain.ReissuedToken;
 import com.cotato.kampus.domain.auth.dto.request.SignupRequest;
 import com.cotato.kampus.domain.auth.dto.response.SignupResponse;
 import com.cotato.kampus.global.common.dto.DataResponse;
@@ -16,6 +20,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +32,10 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final AuthService authService;
+	private final RefreshService refreshService;
+
+	private static final String ACCESS_TOKEN_HEADER = HttpHeaders.AUTHORIZATION;
+	private static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
 
 	@PostMapping("/signup")
 	@Operation(summary = "일반 로그인", description = "Client 단에서 소셜 로그인 후 회원가입 요청하는 api")
@@ -35,6 +45,17 @@ public class AuthController {
 		return ResponseEntity.ok(DataResponse.from(SignupResponse.of(
 			authService.signup(request.email(), request.uniqueId(), request.providerId(), request.username(),
 				request.nickname(), request.nationality(), request.languageCode()))));
+	}
+
+	@PostMapping("/reissue")
+	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 통해 토큰 재발급하는 API")
+	public ResponseEntity<DataResponse<Void>> reissueAccessToken(final HttpServletRequest request,
+		final HttpServletResponse response) {
+		ReissuedToken reissuedToken = refreshService.reissueRefreshToken(
+			request.getHeader(REFRESH_TOKEN_HEADER));
+		response.addHeader(ACCESS_TOKEN_HEADER, reissuedToken.accessToken());
+		response.addHeader(REFRESH_TOKEN_HEADER, reissuedToken.refreshToken());
+		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 
 	@Operation(summary = "서버 헬스 체크", description = "서버 헬스 체크")

--- a/src/main/java/com/cotato/kampus/domain/auth/application/RefreshService.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/application/RefreshService.java
@@ -1,13 +1,15 @@
 package com.cotato.kampus.domain.auth.application;
 
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.auth.dao.RefreshRepository;
 import com.cotato.kampus.domain.auth.domain.RefreshEntity;
+import com.cotato.kampus.domain.auth.domain.ReissuedToken;
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.JwtAuthenticationException;
 import com.cotato.kampus.global.util.JwtUtil;
 
 import jakarta.servlet.http.Cookie;
@@ -17,37 +19,56 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class RefreshService {
 
 	private final RefreshRepository refreshRepository;
 	private final JwtUtil jwtUtil;
 
-	public Map<String, String> reissueRefreshToken(String refresh) {
-		Map<String, String> map = new HashMap<>();
+	private static final String TOKEN_PREFIX = "Bearer";
+	private static final Long ACCESS_TOKEN_EXP = 604800000L; // 일주일
+	private static final Long REFRESH_TOKEN_EXP = 86400000L;
 
-		String uniqueId = jwtUtil.getUniqueId(refresh);
-		String username = jwtUtil.getUsername(refresh);
-		String role = jwtUtil.getRole(refresh);
+	@Transactional
+	public ReissuedToken reissueRefreshToken(String refresh) {
+
+		// 요청 헤더에서 Authorization 값 추출
+		log.info(refresh);
+		if (refresh == null || !refresh.startsWith("Bearer ")) {
+			log.error("Authorization header is missing or does not start with Bearer");
+			throw new JwtAuthenticationException(ErrorCode.INVALID_TOKEN);
+		}
+
+		// "Bearer " 이후의 토큰 값만 추출
+		String token = refresh.substring(7).trim();
+
+		String uniqueId = jwtUtil.getUniqueId(token);
+		String username = jwtUtil.getUsername(token);
+		String role = jwtUtil.getRole(token);
 
 		//make new JWT
-		String newAccess = jwtUtil.createJwt("access", uniqueId, username, role, 600000L);
-		String newRefresh = jwtUtil.createJwt("refresh", uniqueId, username, role, 86400000L);
-		map.put("access", newAccess);
-		map.put("refresh", newRefresh);
+		String newAccess = jwtUtil.createJwt("access", uniqueId, username, role, ACCESS_TOKEN_EXP);
+		String newRefresh = jwtUtil.createJwt("refresh", uniqueId, username, role, REFRESH_TOKEN_EXP);
+		ReissuedToken reissuedToken = ReissuedToken.builder()
+			.accessToken(TOKEN_PREFIX + " " + newAccess)
+			.refreshToken(TOKEN_PREFIX + " " + newRefresh)
+			.build();
 
-		log.info("New refresh: " + newRefresh + " access: " + newAccess);
+		log.info("Access Token : {} ", TOKEN_PREFIX + " " + newAccess);
+		log.info("Refresh Token : {} ", TOKEN_PREFIX + " " + newRefresh);
 
 		//Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
-		refreshRepository.deleteByRefresh(refresh);
-		addRefreshEntity(uniqueId, username, newRefresh, 86400000L);
-
-		return map;
+		addRefreshEntity(uniqueId, username, newRefresh, REFRESH_TOKEN_EXP);
+		return reissuedToken;
 	}
 
-	public void addRefreshEntity(String uniqueId, String username, String refresh, Long expiredMs) {
-		//증복 저장x 구현해야함
-		Date date = new Date(System.currentTimeMillis() + expiredMs);
+	@Transactional
+	public void addRefreshEntity(String uniqueId, String username, String refresh, Long expiration) {
+		Date date = new Date(System.currentTimeMillis() + expiration);
 
+		if (refreshRepository.existsByUniqueId(uniqueId)) {
+			refreshRepository.deleteByUniqueId(uniqueId);
+		}
 		RefreshEntity refreshEntity = RefreshEntity.builder()
 			.uniqueId(uniqueId)
 			.username(username)

--- a/src/main/java/com/cotato/kampus/domain/auth/dao/RefreshRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/dao/RefreshRepository.java
@@ -6,5 +6,7 @@ import com.cotato.kampus.domain.auth.domain.RefreshEntity;
 
 public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
 
-	void deleteByRefresh(String refresh);
+	boolean existsByUniqueId(String uniqueId);
+
+	void deleteByUniqueId(String uniqueId);
 }

--- a/src/main/java/com/cotato/kampus/domain/auth/domain/RefreshEntity.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/domain/RefreshEntity.java
@@ -5,20 +5,26 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "refresh_entity")
+@Table(name = "refresh_entity", indexes = {
+	@Index(name = "idx_unique_id", columnList = "unique_id")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "unique_id", nullable = false)
+	@Column(name = "unique_id", nullable = false, unique = true)
 	private String uniqueId;
 
 	@Column(name = "username", nullable = false)

--- a/src/main/java/com/cotato/kampus/domain/auth/domain/ReissuedToken.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/domain/ReissuedToken.java
@@ -1,0 +1,10 @@
+package com.cotato.kampus.domain.auth.domain;
+
+import lombok.Builder;
+
+@Builder
+public record ReissuedToken(
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/cotato/kampus/global/auth/config/SecurityConfig.java
+++ b/src/main/java/com/cotato/kampus/global/auth/config/SecurityConfig.java
@@ -46,13 +46,15 @@ public class SecurityConfig {
 		"/websocket/**",
 		"/v1/api/chats/**",
 		"/swagger-ui/**",
-		"/v3/api-docs/**"
+		"/v3/api-docs/**",
+		"/v1/api/auth/reissue"
 	};
 
 	// jwtAuthenticationFilter에서 스킵하는 url
 	private static final String[] JWT_SKIP_URL = {
 		"/v1/api/auth/login",
-		"/v1/api/auth/signup"
+		"/v1/api/auth/signup",
+		"/v1/api/auth/reissue"
 	};
 
 	// nativeAppLoginFilter > nativeAppAuthFilter

--- a/src/main/java/com/cotato/kampus/global/common/dto/DataResponse.java
+++ b/src/main/java/com/cotato/kampus/global/common/dto/DataResponse.java
@@ -25,4 +25,11 @@ public class DataResponse<T> extends BaseResponse {
 		return new DataResponse<>(HttpStatus.OK, null);
 	}
 
+	public static <T> DataResponse<T> created(T data) {
+		return new DataResponse<>(HttpStatus.CREATED, data);
+	}
+
+	public static <T> DataResponse<T> created() {
+		return new DataResponse<>(HttpStatus.CREATED, null);
+	}
 }

--- a/src/main/java/com/cotato/kampus/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cotato/kampus/global/error/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.cotato.kampus.global.error.handler;
 
+import java.security.SignatureException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -17,6 +19,8 @@ import com.cotato.kampus.global.error.exception.UnivCertException;
 import com.cotato.kampus.global.error.response.ErrorResponse;
 import com.deepl.api.DeepLException;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
@@ -159,5 +163,31 @@ public class GlobalExceptionHandler {
 		ErrorResponse errorResponse = ErrorResponse.of(request, e.getErrorCode(), e.getDetailMessage());
 		return ResponseEntity.status(e.getErrorCode().getHttpStatus())
 			.body(errorResponse);
+	}
+
+	// JWT 관련 예외 처리
+	@ExceptionHandler(MalformedJwtException.class)
+	public ResponseEntity<ErrorResponse> handleMalformedJwtException(MalformedJwtException e,
+		HttpServletRequest request) {
+		log.error("잘못된 형식의 JWT 토큰: {}", e.getMessage());
+		log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_TOKEN, request);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+	}
+
+	@ExceptionHandler(ExpiredJwtException.class)
+	public ResponseEntity<ErrorResponse> handleExpiredJwtException(ExpiredJwtException e, HttpServletRequest request) {
+		log.error("만료된 JWT 토큰: {}", e.getMessage());
+		log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.TOKEN_EXPIRED, request);
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+	}
+
+	@ExceptionHandler(SignatureException.class)
+	public ResponseEntity<ErrorResponse> handleSignatureException(SignatureException e, HttpServletRequest request) {
+		log.error("JWT 서명 검증 실패: {}", e.getMessage());
+		log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_TOKEN, request);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
 	}
 }

--- a/src/test/java/com/cotato/kampus/domain/auth/application/RefreshServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/auth/application/RefreshServiceTest.java
@@ -1,0 +1,145 @@
+package com.cotato.kampus.domain.auth.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.kampus.domain.auth.dao.RefreshRepository;
+import com.cotato.kampus.domain.auth.domain.RefreshEntity;
+import com.cotato.kampus.domain.auth.domain.ReissuedToken;
+import com.cotato.kampus.domain.auth.factory.TokenTestDataFactory;
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.JwtAuthenticationException;
+import com.cotato.kampus.global.util.JwtUtil;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshServiceTest {
+
+	@Mock
+	private RefreshRepository refreshRepository;
+
+	@Mock
+	private JwtUtil jwtUtil;
+
+	@InjectMocks
+	private RefreshService refreshService;
+
+	private String validRefreshToken;
+	private String rawValidRefreshToken;
+	private String testRefreshToken;
+
+	@BeforeEach
+	void setUp() {
+		rawValidRefreshToken = TokenTestDataFactory.createRefreshToken();
+		validRefreshToken = TokenTestDataFactory.createBearerRefreshToken();
+		testRefreshToken = TokenTestDataFactory.createRefreshToken();
+	}
+
+	@Test
+	@DisplayName("유효한 리프레시 토큰으로 요청 시 새로운 액세스 토큰과 리프레시 토큰을 발급하고 DB에 저장한다")
+	void reissueRefreshToken_withValidToken_shouldReissueAndSaveTokens() {
+		// given
+		String newAccessToken = TokenTestDataFactory.createAccessToken();
+		String newRefreshToken = TokenTestDataFactory.createRefreshToken();
+
+		when(jwtUtil.getUniqueId(rawValidRefreshToken)).thenReturn(TokenTestDataFactory.TEST_UNIQUE_ID);
+		when(jwtUtil.getUsername(rawValidRefreshToken)).thenReturn(TokenTestDataFactory.TEST_USERNAME);
+		when(jwtUtil.getRole(rawValidRefreshToken)).thenReturn(TokenTestDataFactory.TEST_ROLE);
+		when(jwtUtil.createJwt("access", TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
+			TokenTestDataFactory.TEST_ROLE, TokenTestDataFactory.ACCESS_TOKEN_EXP))
+			.thenReturn(newAccessToken);
+		when(jwtUtil.createJwt("refresh", TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
+			TokenTestDataFactory.TEST_ROLE, TokenTestDataFactory.REFRESH_TOKEN_EXP))
+			.thenReturn(newRefreshToken);
+		when(refreshRepository.existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID)).thenReturn(true);
+
+		// when
+		ReissuedToken reissuedToken = refreshService.reissueRefreshToken(validRefreshToken);
+
+		// then
+		assertNotNull(reissuedToken);
+		assertEquals(TokenTestDataFactory.TOKEN_PREFIX + newAccessToken, reissuedToken.accessToken());
+		assertEquals(TokenTestDataFactory.TOKEN_PREFIX + newRefreshToken, reissuedToken.refreshToken());
+
+		verify(refreshRepository).existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
+		verify(refreshRepository).deleteByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
+
+		ArgumentCaptor<RefreshEntity> refreshEntityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
+		verify(refreshRepository).save(refreshEntityCaptor.capture());
+		RefreshEntity savedEntity = refreshEntityCaptor.getValue();
+
+		assertEquals(TokenTestDataFactory.TEST_UNIQUE_ID, savedEntity.getUniqueId());
+		assertEquals(TokenTestDataFactory.TEST_USERNAME, savedEntity.getUsername());
+		assertEquals(newRefreshToken, savedEntity.getRefresh());
+		assertNotNull(savedEntity.getExpiration());
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {"InvalidToken", "BearerInvalid", "Bearer"})
+	@DisplayName("유효하지 않은 형식의 리프레시 토큰으로 요청 시 JwtAuthenticationException 발생")
+	void reissueRefreshToken_withInvalidTokenFormat_shouldThrowJwtAuthenticationException(String invalidToken) {
+		// when & then
+		JwtAuthenticationException exception = assertThrows(JwtAuthenticationException.class, () -> {
+			refreshService.reissueRefreshToken(invalidToken);
+		});
+		assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("기존에 해당 uniqueId의 리프레시 토큰이 존재하면 삭제 후 새로 저장한다")
+	void addRefreshEntity_whenTokenExists_shouldDeleteAndSave() {
+		// given
+		when(refreshRepository.existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID)).thenReturn(true);
+
+		// when
+		refreshService.addRefreshEntity(TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
+			testRefreshToken, TokenTestDataFactory.REFRESH_TOKEN_EXP);
+
+		// then
+		verify(refreshRepository).deleteByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
+
+		ArgumentCaptor<RefreshEntity> refreshEntityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
+		verify(refreshRepository).save(refreshEntityCaptor.capture());
+		RefreshEntity savedEntity = refreshEntityCaptor.getValue();
+
+		assertEquals(TokenTestDataFactory.TEST_UNIQUE_ID, savedEntity.getUniqueId());
+		assertEquals(TokenTestDataFactory.TEST_USERNAME, savedEntity.getUsername());
+		assertEquals(testRefreshToken, savedEntity.getRefresh());
+		assertNotNull(savedEntity.getExpiration());
+	}
+
+	@Test
+	@DisplayName("기존에 해당 uniqueId의 리프레시 토큰이 없으면 바로 새로 저장한다")
+	void addRefreshEntity_whenTokenNotExists_shouldSave() {
+		// given
+		when(refreshRepository.existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID)).thenReturn(false);
+
+		// when
+		refreshService.addRefreshEntity(TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
+			testRefreshToken, TokenTestDataFactory.REFRESH_TOKEN_EXP);
+
+		// then
+		verify(refreshRepository, never()).deleteByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
+
+		ArgumentCaptor<RefreshEntity> refreshEntityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
+		verify(refreshRepository).save(refreshEntityCaptor.capture());
+		RefreshEntity savedEntity = refreshEntityCaptor.getValue();
+
+		assertEquals(TokenTestDataFactory.TEST_UNIQUE_ID, savedEntity.getUniqueId());
+		assertEquals(TokenTestDataFactory.TEST_USERNAME, savedEntity.getUsername());
+		assertEquals(testRefreshToken, savedEntity.getRefresh());
+		assertNotNull(savedEntity.getExpiration());
+	}
+}

--- a/src/test/java/com/cotato/kampus/domain/auth/factory/TokenTestDataFactory.java
+++ b/src/test/java/com/cotato/kampus/domain/auth/factory/TokenTestDataFactory.java
@@ -1,0 +1,34 @@
+package com.cotato.kampus.domain.auth.factory;
+
+// 테스트용 토큰 데이터를 생성하는 Factory 클래스
+public class TokenTestDataFactory {
+
+	public static final String TOKEN_PREFIX = "Bearer ";
+	public static final Long ACCESS_TOKEN_EXP = 604800000L;
+	public static final Long REFRESH_TOKEN_EXP = 86400000L;
+
+	// 테스트 사용자 정보
+	public static final String TEST_UNIQUE_ID = "testUniqueId";
+	public static final String TEST_USERNAME = "testUser";
+	public static final String TEST_ROLE = "ROLE_USER";
+
+	// 액세스 토큰 생성
+	public static String createAccessToken() {
+		return "test-access-token";
+	}
+
+	// 리프레시 토큰 생성
+	public static String createRefreshToken() {
+		return "test-refresh-token";
+	}
+
+	// Bearer 형식의 액세스 토큰 생성
+	public static String createBearerAccessToken() {
+		return TOKEN_PREFIX + createAccessToken();
+	}
+
+	// Bearer 형식의 리프레시 토큰 생성
+	public static String createBearerRefreshToken() {
+		return TOKEN_PREFIX + createRefreshToken();
+	}
+}


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
토큰 만료시 재발급 API 구현

### 상세 내용(Describe your changes)
reissue는 `jwtAuthenticationFilter`에서 처리되지 않아야 하고, 또 `accessToken`이 만료된 상태기 때문에, 인가도 필요없는 API로 구성되어야 하여, `WHITE_LIST`, `SKIP_URL`에 둘다 포함시켰습니다.

또한 토큰과 관련된 예외는 원래 JwtExceptionFilter에서 처리되어 `GlobalExceptionHandler`를 거치지 않고 처리되었는데,
이 api는 필터를 스킵하기 때문에, GlobalExceptionHandler에서 토큰 관련 예외를 잡는 핸들러를 추가하였습니다.


### Issue Number or Link
Resolved #260 