### PR TITLE
[FEATURE] 리프레시 토큰 쿠키에 저장하는 로직 구현

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/auth/api/AuthController.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/api/AuthController.java
@@ -14,12 +14,14 @@ import com.cotato.kampus.domain.auth.application.RefreshService;
 import com.cotato.kampus.domain.auth.domain.ReissuedToken;
 import com.cotato.kampus.domain.auth.dto.request.SignupRequest;
 import com.cotato.kampus.domain.auth.dto.response.SignupResponse;
+import com.cotato.kampus.global.auth.util.CookieUtil;
 import com.cotato.kampus.global.common.dto.DataResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
@@ -51,10 +53,17 @@ public class AuthController {
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 통해 토큰 재발급하는 API")
 	public ResponseEntity<DataResponse<Void>> reissueAccessToken(final HttpServletRequest request,
 		final HttpServletResponse response) {
+
+		// 리프레시 토큰을 쿠키에서 추출하여 재발급
 		ReissuedToken reissuedToken = refreshService.reissueRefreshToken(
-			request.getHeader(REFRESH_TOKEN_HEADER));
+			CookieUtil.extractRefreshToken(request)
+		);
+
+		// 재발급된 토큰을 응답 헤더와 쿠키에 추가
 		response.addHeader(ACCESS_TOKEN_HEADER, reissuedToken.accessToken());
-		response.addHeader(REFRESH_TOKEN_HEADER, reissuedToken.refreshToken());
+		Cookie refreshCookie = CookieUtil.createRefreshCookie(reissuedToken.refreshToken());
+		response.addCookie(refreshCookie);
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created());
 	}
 

--- a/src/main/java/com/cotato/kampus/domain/auth/application/RefreshService.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/application/RefreshService.java
@@ -1,18 +1,13 @@
 package com.cotato.kampus.domain.auth.application;
 
-import java.util.Date;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.auth.dao.RefreshRepository;
-import com.cotato.kampus.domain.auth.domain.RefreshEntity;
 import com.cotato.kampus.domain.auth.domain.ReissuedToken;
-import com.cotato.kampus.global.error.ErrorCode;
-import com.cotato.kampus.global.error.exception.JwtAuthenticationException;
+import com.cotato.kampus.domain.auth.implement.RefreshManager;
 import com.cotato.kampus.global.util.JwtUtil;
 
-import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RefreshService {
 
 	private final RefreshRepository refreshRepository;
+	private final RefreshManager refreshManager;
 	private final JwtUtil jwtUtil;
 
 	private static final String TOKEN_PREFIX = "Bearer";
@@ -30,63 +26,30 @@ public class RefreshService {
 	private static final Long REFRESH_TOKEN_EXP = 86400000L;
 
 	@Transactional
-	public ReissuedToken reissueRefreshToken(String refresh) {
+	public ReissuedToken reissueRefreshToken(final String refresh) {
 
 		// 요청 헤더에서 Authorization 값 추출
 		log.info(refresh);
-		if (refresh == null || !refresh.startsWith("Bearer ")) {
-			log.error("Authorization header is missing or does not start with Bearer");
-			throw new JwtAuthenticationException(ErrorCode.INVALID_TOKEN);
-		}
 
-		// "Bearer " 이후의 토큰 값만 추출
-		String token = refresh.substring(7).trim();
+		String uniqueId = jwtUtil.getUniqueId(refresh);
+		String username = jwtUtil.getUsername(refresh);
+		String role = jwtUtil.getRole(refresh);
 
-		String uniqueId = jwtUtil.getUniqueId(token);
-		String username = jwtUtil.getUsername(token);
-		String role = jwtUtil.getRole(token);
-
-		//make new JWT
+		// make new JWT
 		String newAccess = jwtUtil.createJwt("access", uniqueId, username, role, ACCESS_TOKEN_EXP);
 		String newRefresh = jwtUtil.createJwt("refresh", uniqueId, username, role, REFRESH_TOKEN_EXP);
+
+		// Refresh 토큰에는 Bearer 접두어 X(쿠키에 저장)
 		ReissuedToken reissuedToken = ReissuedToken.builder()
 			.accessToken(TOKEN_PREFIX + " " + newAccess)
-			.refreshToken(TOKEN_PREFIX + " " + newRefresh)
+			.refreshToken(newRefresh)
 			.build();
 
-		log.info("Access Token : {} ", TOKEN_PREFIX + " " + newAccess);
-		log.info("Refresh Token : {} ", TOKEN_PREFIX + " " + newRefresh);
+		log.info("Access Token : {} ", newAccess);
+		log.info("Refresh Token : {} ", newRefresh);
 
 		//Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
-		addRefreshEntity(uniqueId, username, newRefresh, REFRESH_TOKEN_EXP);
+		refreshManager.addRefreshEntity(uniqueId, username, newRefresh, REFRESH_TOKEN_EXP);
 		return reissuedToken;
-	}
-
-	@Transactional
-	public void addRefreshEntity(String uniqueId, String username, String refresh, Long expiration) {
-		Date date = new Date(System.currentTimeMillis() + expiration);
-
-		if (refreshRepository.existsByUniqueId(uniqueId)) {
-			refreshRepository.deleteByUniqueId(uniqueId);
-		}
-		RefreshEntity refreshEntity = RefreshEntity.builder()
-			.uniqueId(uniqueId)
-			.username(username)
-			.refresh(refresh)
-			.expiration(date.toString())
-			.build();
-
-		refreshRepository.save(refreshEntity);
-	}
-
-	public Cookie createCookie(String key, String value) {
-
-		Cookie cookie = new Cookie(key, value);
-		cookie.setMaxAge(24 * 60 * 60);
-		//cookie.setSecure(true);
-		cookie.setPath("/");  //모든 위치에서 쿠키를 볼 수 있음
-		cookie.setHttpOnly(true); //자바스크립트가 쿠키를 가져가지 못하게 함
-
-		return cookie;
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/auth/implement/RefreshManager.java
+++ b/src/main/java/com/cotato/kampus/domain/auth/implement/RefreshManager.java
@@ -1,0 +1,37 @@
+package com.cotato.kampus.domain.auth.implement;
+
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.cotato.kampus.domain.auth.dao.RefreshRepository;
+import com.cotato.kampus.domain.auth.domain.RefreshEntity;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Transactional(readOnly = true)
+public class RefreshManager {
+
+	private final RefreshRepository refreshRepository;
+
+	@Transactional
+	public void addRefreshEntity(String uniqueId, String username, String refresh, Long expiration) {
+		Date date = new Date(System.currentTimeMillis() + expiration);
+
+		if (refreshRepository.existsByUniqueId(uniqueId)) {
+			refreshRepository.deleteByUniqueId(uniqueId);
+		}
+		RefreshEntity refreshEntity = RefreshEntity.builder()
+			.uniqueId(uniqueId)
+			.username(username)
+			.refresh(refresh)
+			.expiration(date.toString())
+			.build();
+
+		refreshRepository.save(refreshEntity);
+	}
+}

--- a/src/main/java/com/cotato/kampus/global/auth/oauth/handler/OAuthSuccessHandler.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/handler/OAuthSuccessHandler.java
@@ -9,10 +9,12 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import com.cotato.kampus.domain.auth.application.RefreshService;
+import com.cotato.kampus.domain.auth.implement.RefreshManager;
 import com.cotato.kampus.global.auth.oauth.service.dto.CustomOAuth2User;
+import com.cotato.kampus.global.auth.util.CookieUtil;
 import com.cotato.kampus.global.util.JwtUtil;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 	private final JwtUtil jwtUtil;
-	private final RefreshService refreshService;
+	private final RefreshManager refreshManager;
 
 	private static final String ACCESS_HEADER_NAME = "Authorization";
 	private static final String REFRESH_HEADER_NAME = "Refresh-Token";
@@ -59,14 +61,16 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 		String access = jwtUtil.createJwt("access", uniqueId, username, role, ACCESS_TOKEN_EXP);
 		String refresh = jwtUtil.createJwt("refresh", uniqueId, username, role, REFRESH_TOKEN_EXP);
 
-		refreshService.addRefreshEntity(uniqueId, username, refresh, 86400000L);
+		refreshManager.addRefreshEntity(uniqueId, username, refresh, 86400000L);
 
 		log.info("Access Token : {} ", TOKEN_PREFIX + " " + access);
 		log.info("Refresh Token : {} ", TOKEN_PREFIX + " " + refresh);
 
-		// Bearer 토큰을 헤더에 추가
-		response.setHeader(ACCESS_HEADER_NAME, TOKEN_PREFIX + access);
-		response.setHeader(REFRESH_HEADER_NAME, TOKEN_PREFIX + refresh);
+		// 엑세스 토큰과 리프레시 토큰을 응답 헤더와 쿠키에 설정
+		response.setHeader(ACCESS_HEADER_NAME, TOKEN_PREFIX + " " + access);
+		Cookie refreshCookie = CookieUtil.createRefreshCookie(refresh);
+		response.addCookie(refreshCookie);
+		log.info("Refresh Cookie: {}", refreshCookie.getName() + "=" + refreshCookie.getValue());
 
 		// 로컬 환경에서 개발할 때는 로컬로 리다이렉트 되도록 설정(추후 삭제 예정)
 		String finalRedirectUrl = isDevelopment(request) ? DEV_REDIRECT_URL : REDIRECT_URL;

--- a/src/main/java/com/cotato/kampus/global/auth/util/CookieUtil.java
+++ b/src/main/java/com/cotato/kampus/global/auth/util/CookieUtil.java
@@ -1,0 +1,34 @@
+package com.cotato.kampus.global.auth.util;
+
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.AppException;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class CookieUtil {
+
+	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+	private static final int COOKIE_MAX_AGE = 60 * 60 * 24 * 3;
+
+	public static Cookie createRefreshCookie(final String refreshToken) {
+		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setSecure(true);
+		cookie.setMaxAge(COOKIE_MAX_AGE);
+		return cookie;
+	}
+
+	public static String extractRefreshToken(HttpServletRequest request) {
+		if (request.getCookies() != null) {
+			for (Cookie cookie : request.getCookies()) {
+				if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+					return cookie.getValue();
+				}
+			}
+		}
+		throw new AppException(ErrorCode.COOKIE_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/cotato/kampus/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cotato/kampus/global/config/SwaggerConfig.java
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.models.servers.Server;
 public class SwaggerConfig {
 
 	private static final String ACCESS_HEADER_NAME = "Authorization";
-	private static final String REFRESH_HEADER_NAME = "Refresh-Token";
+	private static final String REFRESH_COOKIE_NAME = "refreshCookie";
 
 	@Bean
 	public OpenAPI customOpenAPI() {
@@ -29,7 +29,7 @@ public class SwaggerConfig {
 		// Define the SecurityRequirement to be included in the request
 		SecurityRequirement securityRequirement = new SecurityRequirement()
 			.addList(ACCESS_HEADER_NAME)
-			.addList(REFRESH_HEADER_NAME);
+			.addList(REFRESH_COOKIE_NAME);
 
 		Components components = new Components()
 			.addSecuritySchemes(ACCESS_HEADER_NAME, new SecurityScheme()
@@ -37,11 +37,11 @@ public class SwaggerConfig {
 				.type(SecurityScheme.Type.APIKEY)
 				.in(SecurityScheme.In.HEADER)
 				.name(ACCESS_HEADER_NAME))
-			.addSecuritySchemes(REFRESH_HEADER_NAME, new SecurityScheme()
-				.name(REFRESH_HEADER_NAME)
+			.addSecuritySchemes(REFRESH_COOKIE_NAME, new SecurityScheme()
+				.name(REFRESH_COOKIE_NAME)
 				.type(SecurityScheme.Type.APIKEY)
-				.in(SecurityScheme.In.HEADER)
-				.name(REFRESH_HEADER_NAME));
+				.in(SecurityScheme.In.COOKIE)
+				.name(REFRESH_COOKIE_NAME));
 
 		return new OpenAPI()
 			.addServersItem(new Server().url("https://kampus.kro.kr").description("배포 서버"))

--- a/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
+++ b/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
@@ -185,6 +185,9 @@ public enum ErrorCode {
 
 	// UnivCert
 	UNIVCERT_ERROR(HttpStatus.BAD_REQUEST, "대학 이메일 인증 중 오류가 발생하였습니다.", "UNIVCERT-001"),
+
+	// Cookie
+	COOKIE_NOT_FOUND(HttpStatus.BAD_REQUEST, "요청에 쿠키가 존재하지 않습니다.", "COOKIE-001"),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/java/com/cotato/kampus/domain/auth/application/RefreshServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/auth/application/RefreshServiceTest.java
@@ -1,145 +1,73 @@
 package com.cotato.kampus.domain.auth.application;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cotato.kampus.domain.auth.dao.RefreshRepository;
-import com.cotato.kampus.domain.auth.domain.RefreshEntity;
 import com.cotato.kampus.domain.auth.domain.ReissuedToken;
 import com.cotato.kampus.domain.auth.factory.TokenTestDataFactory;
-import com.cotato.kampus.global.error.ErrorCode;
-import com.cotato.kampus.global.error.exception.JwtAuthenticationException;
+import com.cotato.kampus.domain.auth.implement.RefreshManager;
 import com.cotato.kampus.global.util.JwtUtil;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("RefreshService 테스트")
 class RefreshServiceTest {
+
+	@InjectMocks
+	private RefreshService refreshService;
 
 	@Mock
 	private RefreshRepository refreshRepository;
 
 	@Mock
+	private RefreshManager refreshManager;
+
+	@Mock
 	private JwtUtil jwtUtil;
 
-	@InjectMocks
-	private RefreshService refreshService;
-
-	private String validRefreshToken;
-	private String rawValidRefreshToken;
-	private String testRefreshToken;
-
-	@BeforeEach
-	void setUp() {
-		rawValidRefreshToken = TokenTestDataFactory.createRefreshToken();
-		validRefreshToken = TokenTestDataFactory.createBearerRefreshToken();
-		testRefreshToken = TokenTestDataFactory.createRefreshToken();
-	}
-
 	@Test
-	@DisplayName("유효한 리프레시 토큰으로 요청 시 새로운 액세스 토큰과 리프레시 토큰을 발급하고 DB에 저장한다")
-	void reissueRefreshToken_withValidToken_shouldReissueAndSaveTokens() {
+	@DisplayName("리프레시 토큰 재발급 - 성공")
+	void reissueRefreshToken_Success() {
 		// given
-		String newAccessToken = TokenTestDataFactory.createAccessToken();
-		String newRefreshToken = TokenTestDataFactory.createRefreshToken();
+		String inputRefreshToken = TokenTestDataFactory.createRefreshToken();
+		String expectedNewAccessToken = "new-access-token";
+		String expectedNewRefreshToken = "new-refresh-token";
 
-		when(jwtUtil.getUniqueId(rawValidRefreshToken)).thenReturn(TokenTestDataFactory.TEST_UNIQUE_ID);
-		when(jwtUtil.getUsername(rawValidRefreshToken)).thenReturn(TokenTestDataFactory.TEST_USERNAME);
-		when(jwtUtil.getRole(rawValidRefreshToken)).thenReturn(TokenTestDataFactory.TEST_ROLE);
-		when(jwtUtil.createJwt("access", TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
-			TokenTestDataFactory.TEST_ROLE, TokenTestDataFactory.ACCESS_TOKEN_EXP))
-			.thenReturn(newAccessToken);
-		when(jwtUtil.createJwt("refresh", TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
-			TokenTestDataFactory.TEST_ROLE, TokenTestDataFactory.REFRESH_TOKEN_EXP))
-			.thenReturn(newRefreshToken);
-		when(refreshRepository.existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID)).thenReturn(true);
+		// JwtUtil 모킹
+		when(jwtUtil.getUniqueId(inputRefreshToken)).thenReturn(TokenTestDataFactory.TEST_UNIQUE_ID);
+		when(jwtUtil.getUsername(inputRefreshToken)).thenReturn(TokenTestDataFactory.TEST_USERNAME);
+		when(jwtUtil.getRole(inputRefreshToken)).thenReturn(TokenTestDataFactory.TEST_ROLE);
+
+		when(jwtUtil.createJwt(
+			eq("access"),
+			eq(TokenTestDataFactory.TEST_UNIQUE_ID),
+			eq(TokenTestDataFactory.TEST_USERNAME),
+			eq(TokenTestDataFactory.TEST_ROLE),
+			eq(604800000L)
+		)).thenReturn(expectedNewAccessToken);
+
+		when(jwtUtil.createJwt(
+			eq("refresh"),
+			eq(TokenTestDataFactory.TEST_UNIQUE_ID),
+			eq(TokenTestDataFactory.TEST_USERNAME),
+			eq(TokenTestDataFactory.TEST_ROLE),
+			eq(86400000L)
+		)).thenReturn(expectedNewRefreshToken);
 
 		// when
-		ReissuedToken reissuedToken = refreshService.reissueRefreshToken(validRefreshToken);
+		ReissuedToken result = refreshService.reissueRefreshToken(inputRefreshToken);
 
 		// then
-		assertNotNull(reissuedToken);
-		assertEquals(TokenTestDataFactory.TOKEN_PREFIX + newAccessToken, reissuedToken.accessToken());
-		assertEquals(TokenTestDataFactory.TOKEN_PREFIX + newRefreshToken, reissuedToken.refreshToken());
-
-		verify(refreshRepository).existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
-		verify(refreshRepository).deleteByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
-
-		ArgumentCaptor<RefreshEntity> refreshEntityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
-		verify(refreshRepository).save(refreshEntityCaptor.capture());
-		RefreshEntity savedEntity = refreshEntityCaptor.getValue();
-
-		assertEquals(TokenTestDataFactory.TEST_UNIQUE_ID, savedEntity.getUniqueId());
-		assertEquals(TokenTestDataFactory.TEST_USERNAME, savedEntity.getUsername());
-		assertEquals(newRefreshToken, savedEntity.getRefresh());
-		assertNotNull(savedEntity.getExpiration());
-	}
-
-	@ParameterizedTest
-	@NullAndEmptySource
-	@ValueSource(strings = {"InvalidToken", "BearerInvalid", "Bearer"})
-	@DisplayName("유효하지 않은 형식의 리프레시 토큰으로 요청 시 JwtAuthenticationException 발생")
-	void reissueRefreshToken_withInvalidTokenFormat_shouldThrowJwtAuthenticationException(String invalidToken) {
-		// when & then
-		JwtAuthenticationException exception = assertThrows(JwtAuthenticationException.class, () -> {
-			refreshService.reissueRefreshToken(invalidToken);
-		});
-		assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
-	}
-
-	@Test
-	@DisplayName("기존에 해당 uniqueId의 리프레시 토큰이 존재하면 삭제 후 새로 저장한다")
-	void addRefreshEntity_whenTokenExists_shouldDeleteAndSave() {
-		// given
-		when(refreshRepository.existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID)).thenReturn(true);
-
-		// when
-		refreshService.addRefreshEntity(TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
-			testRefreshToken, TokenTestDataFactory.REFRESH_TOKEN_EXP);
-
-		// then
-		verify(refreshRepository).deleteByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
-
-		ArgumentCaptor<RefreshEntity> refreshEntityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
-		verify(refreshRepository).save(refreshEntityCaptor.capture());
-		RefreshEntity savedEntity = refreshEntityCaptor.getValue();
-
-		assertEquals(TokenTestDataFactory.TEST_UNIQUE_ID, savedEntity.getUniqueId());
-		assertEquals(TokenTestDataFactory.TEST_USERNAME, savedEntity.getUsername());
-		assertEquals(testRefreshToken, savedEntity.getRefresh());
-		assertNotNull(savedEntity.getExpiration());
-	}
-
-	@Test
-	@DisplayName("기존에 해당 uniqueId의 리프레시 토큰이 없으면 바로 새로 저장한다")
-	void addRefreshEntity_whenTokenNotExists_shouldSave() {
-		// given
-		when(refreshRepository.existsByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID)).thenReturn(false);
-
-		// when
-		refreshService.addRefreshEntity(TokenTestDataFactory.TEST_UNIQUE_ID, TokenTestDataFactory.TEST_USERNAME,
-			testRefreshToken, TokenTestDataFactory.REFRESH_TOKEN_EXP);
-
-		// then
-		verify(refreshRepository, never()).deleteByUniqueId(TokenTestDataFactory.TEST_UNIQUE_ID);
-
-		ArgumentCaptor<RefreshEntity> refreshEntityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
-		verify(refreshRepository).save(refreshEntityCaptor.capture());
-		RefreshEntity savedEntity = refreshEntityCaptor.getValue();
-
-		assertEquals(TokenTestDataFactory.TEST_UNIQUE_ID, savedEntity.getUniqueId());
-		assertEquals(TokenTestDataFactory.TEST_USERNAME, savedEntity.getUsername());
-		assertEquals(testRefreshToken, savedEntity.getRefresh());
-		assertNotNull(savedEntity.getExpiration());
+		assertThat(result).isNotNull();
+		assertThat(result.accessToken()).isEqualTo("Bearer " + expectedNewAccessToken);
+		assertThat(result.refreshToken()).isEqualTo(expectedNewRefreshToken);
 	}
 }

--- a/src/test/java/com/cotato/kampus/domain/auth/implement/RefreshManagerTest.java
+++ b/src/test/java/com/cotato/kampus/domain/auth/implement/RefreshManagerTest.java
@@ -1,0 +1,79 @@
+package com.cotato.kampus.domain.auth.implement;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.kampus.domain.auth.dao.RefreshRepository;
+import com.cotato.kampus.domain.auth.domain.RefreshEntity;
+import com.cotato.kampus.domain.auth.factory.TokenTestDataFactory;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefreshManager 테스트")
+class RefreshManagerTest {
+
+	@InjectMocks
+	private RefreshManager refreshManager;
+
+	@Mock
+	private RefreshRepository refreshRepository;
+
+	@Test
+	@DisplayName("리프레시 엔티티 추가 - 기존 토큰이 없는 경우에는 새로 저장")
+	void addRefreshEntity_NewUser_Success() {
+		// given
+		String uniqueId = TokenTestDataFactory.TEST_UNIQUE_ID;
+		String username = TokenTestDataFactory.TEST_USERNAME;
+		String refreshToken = TokenTestDataFactory.createRefreshToken();
+		Long expiration = TokenTestDataFactory.REFRESH_TOKEN_EXP;
+
+		when(refreshRepository.existsByUniqueId(uniqueId)).thenReturn(false);
+
+		// when
+		refreshManager.addRefreshEntity(uniqueId, username, refreshToken, expiration);
+
+		// then
+		ArgumentCaptor<RefreshEntity> entityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
+		verify(refreshRepository).save(entityCaptor.capture());
+		verify(refreshRepository, never()).deleteByUniqueId(uniqueId);
+
+		RefreshEntity savedEntity = entityCaptor.getValue();
+		assertThat(savedEntity.getUniqueId()).isEqualTo(uniqueId);
+		assertThat(savedEntity.getUsername()).isEqualTo(username);
+		assertThat(savedEntity.getRefresh()).isEqualTo(refreshToken);
+		assertThat(savedEntity.getExpiration()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("리프레시 엔티티 추가 - 기존 토큰이 있는 경우에는 삭제 후 저장")
+	void addRefreshEntity_ExistingUser_DeleteAndSave() {
+		// given
+		String uniqueId = TokenTestDataFactory.TEST_UNIQUE_ID;
+		String username = TokenTestDataFactory.TEST_USERNAME;
+		String refreshToken = TokenTestDataFactory.createRefreshToken();
+		Long expiration = TokenTestDataFactory.REFRESH_TOKEN_EXP;
+
+		when(refreshRepository.existsByUniqueId(uniqueId)).thenReturn(true);
+
+		// when
+		refreshManager.addRefreshEntity(uniqueId, username, refreshToken, expiration);
+
+		// then
+		verify(refreshRepository).deleteByUniqueId(uniqueId);
+
+		ArgumentCaptor<RefreshEntity> entityCaptor = ArgumentCaptor.forClass(RefreshEntity.class);
+		verify(refreshRepository).save(entityCaptor.capture());
+
+		RefreshEntity savedEntity = entityCaptor.getValue();
+		assertThat(savedEntity.getUniqueId()).isEqualTo(uniqueId);
+		assertThat(savedEntity.getUsername()).isEqualTo(username);
+		assertThat(savedEntity.getRefresh()).isEqualTo(refreshToken);
+	}
+}


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
- 리프레시 토큰 쿠키에 저장하도록 구현
- 토큰 재발급 로직에서도 쿠키 사용하도록 변경
- 스웨거 refresh 토큰 쿠키로 받도록 변경
### 상세 내용(Describe your changes)

### Issue Number or Link
resolve #272