### PR TITLE
[REFACTOR] 임시 저장글 목록 조회 응답에 전체 개수 필드 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/post/api/TemporaryPostController.java
+++ b/src/main/java/com/cotato/kampus/domain/post/api/TemporaryPostController.java
@@ -21,6 +21,7 @@ import com.cotato.kampus.domain.post.api.response.PostCreateResponse;
 import com.cotato.kampus.domain.post.api.response.TempPostCreateResponse;
 import com.cotato.kampus.domain.post.api.response.TempPostDetailResponse;
 import com.cotato.kampus.domain.post.api.response.SliceResponse;
+import com.cotato.kampus.domain.post.api.response.TempPostSliceResponse;
 import com.cotato.kampus.domain.post.application.TemporaryPostService;
 import com.cotato.kampus.domain.post.domain.TempPostThumbnail;
 import com.cotato.kampus.global.common.dto.DataResponse;
@@ -62,12 +63,14 @@ public class TemporaryPostController {
 
 	@GetMapping(value = "/draft")
 	@Operation(summary = "임시 저장글 목록 조회", description = "모든 임시 저장글을 최신순으로 조회합니다.")
-	public ResponseEntity<DataResponse<SliceResponse<TempPostThumbnail>>> findDraftList(
+	public ResponseEntity<DataResponse<TempPostSliceResponse<TempPostThumbnail>>> findDraftList(
 		@RequestParam(required = false, defaultValue = "1") int page
 	) {
+		int totalCount = temporaryPostService.findTempPostCount();
 		return ResponseEntity.ok(DataResponse.from(
-			SliceResponse.from(
+				TempPostSliceResponse.from(
 					temporaryPostService.findPostDrafts(page)
+					,totalCount
 				)
 			)
 		);

--- a/src/main/java/com/cotato/kampus/domain/post/api/response/TempPostSliceResponse.java
+++ b/src/main/java/com/cotato/kampus/domain/post/api/response/TempPostSliceResponse.java
@@ -1,0 +1,21 @@
+package com.cotato.kampus.domain.post.api.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+
+import com.cotato.kampus.domain.post.domain.TempPostThumbnail;
+
+public record TempPostSliceResponse<T>(
+	List<TempPostThumbnail> tempPosts,
+	Boolean hasNext,
+	int totalCount
+) {
+	public static <T> TempPostSliceResponse<T> from (Slice<TempPostThumbnail> tempPosts, int totalCount) {
+		return new TempPostSliceResponse<>(
+			tempPosts.getContent(),
+			tempPosts.hasContent(),
+			totalCount
+		);
+	}
+}


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
임시저장글 목록 조회 API 응답에 totalCount 필드를 포함하도록 수정

### 상세 내용(Describe your changes)
TempPostSliceResponse DTO 생성

### Issue Number or Link
Resolve #295 