### PR TITLE
[REFACTOR] 게시판별 최신 게시글 조회 시 Optional<Post> 기반으로 리팩토링

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
+++ b/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
@@ -3,6 +3,8 @@ package com.cotato.kampus.domain.board.application;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,10 +65,11 @@ public class BoardService {
 
 		// 즐겨찾는 게시판 조회
 		List<Long> favoriteBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userId);
+		Map<Long, Board> boards = boardFinder.findBoardMap(favoriteBoardIds);
 
-		List<Post> latestPosts = postFinder.findTopPosts(favoriteBoardIds);
+		Map<Long, Optional<Post>> latestPosts = postFinder.findTopPosts(favoriteBoardIds);
 
-		return postDtoMapper.toHomePostThumbnails(latestPosts);
+		return postDtoMapper.toHomePostThumbnails(boards, latestPosts);
 	}
 
 	public BoardWithFavoriteStatus getUniversityBoard() {

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -2,6 +2,9 @@ package com.cotato.kampus.domain.board.implement.board;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +45,14 @@ public class BoardFinder {
 
 	public List<Board> findBoardsWithIds(List<Long> boardIds) {
 		return boardRepository.findAllByIdIn(boardIds);
+	}
+
+	public Map<Long, Board> findBoardMap(List<Long> boardIds) {
+		return findBoardsWithIds(boardIds).stream()
+			.collect(Collectors.toMap(
+				Board::getId,
+				Function.identity()
+			));
 	}
 
 	public List<Board> findPublicBoards() {

--- a/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostJpaRepository.java
@@ -66,7 +66,7 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
 	Slice<PostEntity> findAllAccessiblePostsByIds(@Param("postIds") List<Long> postIds, @Param("userUnivId") Long userUnivId,
 		Pageable pageable);
 
-	PostEntity findTopByBoardIdOrderByCreatedTimeDesc(Long boardId);
+	Optional<PostEntity> findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus);
 
 	@Query("""
 		    SELECT DISTINCT p

--- a/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostRepositoryImpl.java
@@ -101,8 +101,9 @@ public class PostRepositoryImpl implements PostRepository {
 	}
 
 	@Override
-	public Post findTopByBoardIdOrderByCreatedTimeDesc(Long boardId) {
-		return postJpaRepository.findTopByBoardIdOrderByCreatedTimeDesc(boardId).toDomain();
+	public Optional<Post> findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus) {
+		return postJpaRepository.findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(boardId, postStatus)
+			.map(PostEntity::toDomain);
 	}
 
 	@Override

--- a/src/main/java/com/cotato/kampus/domain/post/implement/port/PostRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/port/PostRepository.java
@@ -49,7 +49,7 @@ public interface PostRepository {
 		Pageable pageable);
 
 	// 게시판의 최신 게시글 1개 조회
-	Post findTopByBoardIdOrderByCreatedTimeDesc(Long boardId);
+	Optional<Post> findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus);
 
 	// 사용자가 댓글을 작성한 게시글 목록 조회
 	Slice<Post> findPostsByUserComments(Long userId, Pageable pageable);

--- a/src/main/java/com/cotato/kampus/domain/post/implement/post/PostDtoMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/post/PostDtoMapper.java
@@ -1,6 +1,8 @@
 package com.cotato.kampus.domain.post.implement.post;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
@@ -65,5 +67,19 @@ public class PostDtoMapper {
 
 	public List<HomePostThumbnail> toHomePostThumbnails(List<Post> posts) {
 		return posts.stream().map(this::toHomePostThumbnail).toList();
+	}
+
+	public List<HomePostThumbnail> toHomePostThumbnails(
+		Map<Long, Board> boards,
+		Map<Long, Optional<Post>> postsByBoardId
+	) {
+		return boards.entrySet().stream()
+			.map(entry -> {
+				Long boardId = entry.getKey();
+				Board board = entry.getValue();
+				Post post = postsByBoardId.getOrDefault(boardId, Optional.empty()).orElse(null);
+				return HomePostThumbnail.from(board, post);
+			})
+			.toList();
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/post/implement/post/PostFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/post/PostFinder.java
@@ -1,6 +1,10 @@
 package com.cotato.kampus.domain.post.implement.post;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -58,10 +62,15 @@ public class PostFinder {
 		return postRepository.findTopAccessiblePostsByIds(trendingPostIds, userUniversityId, HOME_POST_PREVIEW_LIMIT);
 	}
 
-	public List<Post> findTopPosts(List<Long> boardIds) {
+	public Map<Long, Optional<Post>> findTopPosts(List<Long> boardIds) {
 		return boardIds.stream()
-			.map(postRepository::findTopByBoardIdOrderByCreatedTimeDesc)
-			.toList();
+			.collect(Collectors.toMap(
+				Function.identity(), // boardId
+				boardId -> postRepository.findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(boardId, PostStatus.PUBLISHED)
+			));
+			// .map(postRepository::findTopByBoardIdOrderByCreatedTimeDesc)
+			// .flatMap(Optional::stream)
+			// .toList();
 	}
 
 	public PostReferenceDto findPostReference(Long postId) {


### PR DESCRIPTION
- 게시판별 최신 게시글 조회 시 Optional<Post>로 변경

---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
게시판별 최신 게시글 조회 시 게시글이 없는 경우도 고려할 수 있도록
기존 `List<Post>` 기반 로직을 `Map<boardId, Optional<Post>>` 기반으로 리팩토링

### 상세 내용(Describe your changes)
- 게시판별 최신 게시글 조회 시 `PostStatus.ACTIVE` 조건 추가
- 게시글이 없는 게시판도 대응할 수 있도록 `Optional<Post>` 기반으로 변경
- `BoardFinder`에 `Map<Long, Board>` 반환하는 메서드 추가

### 응답 예시 (게시글이 없는 게시판의 경우)

```json
{
  "status": "OK",
  "data": {
    "homePostThumbnailList": [
      {
        "boardId": 369,
        "boardName": "홍익대학교 게시판",
        "postId": null,
        "postTitle": null
      }
    ]
  },
  "timestamp": "2025-07-20 23:43:40"
}
```

### Issue Number or Link
Resolve #312 