### PR TITLE
test: CookieUtil 테스트 메서드 개선

### DIFF
--- a/src/test/java/com/cotato/kampus/global/auth/util/CookieUtilTest.java
+++ b/src/test/java/com/cotato/kampus/global/auth/util/CookieUtilTest.java
@@ -4,23 +4,29 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import jakarta.servlet.http.Cookie;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class CookieUtilTest {
 
 	@Test
 	@DisplayName("만료된 리프레시 쿠키 생성 검증")
-	void createExpiredRefreshCookie_CreatesCorrectCookie() {
+	void clearRefreshTokenCookie_CreatesCorrectExpiredCookie() {
+		// given
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
 		// when
-		Cookie expiredCookie = CookieUtil.createExpiredRefreshCookie();
+		CookieUtil.clearRefreshTokenCookie(response);
 
 		// then
-		assertEquals("refreshToken", expiredCookie.getName());
-		assertNull(expiredCookie.getValue());
-		assertEquals(0, expiredCookie.getMaxAge());
-		assertEquals("/", expiredCookie.getPath());
-		assertTrue(expiredCookie.getSecure());
+		String setCookieHeader = response.getHeader("Set-Cookie");
+		assertNotNull(setCookieHeader);
+		
+		assertTrue(setCookieHeader.contains("refreshToken="));
+		assertTrue(setCookieHeader.contains("Max-Age=0"));
+		assertTrue(setCookieHeader.contains("Path=/"));
+		assertTrue(setCookieHeader.contains("Secure"));
+		assertTrue(setCookieHeader.contains("HttpOnly"));
+		assertTrue(setCookieHeader.contains("SameSite=None"));
 	}
 
 }


### PR DESCRIPTION
## Summary
- CookieUtil의 만료된 쿠키 생성 테스트를 보다 실제적인 방식으로 개선
- `createExpiredRefreshCookie` 메서드 테스트를 `clearRefreshTokenCookie` 메서드 테스트로 변경
- MockHttpServletResponse를 사용하여 실제 HTTP 응답 헤더 검증 방식으로 개선

## Changes
- 테스트 메서드명 변경: `createExpiredRefreshCookie_CreatesCorrectCookie` → `clearRefreshTokenCookie_CreatesCorrectExpiredCookie`
- MockHttpServletResponse를 사용한 Set-Cookie 헤더 검증 추가
- SameSite=None, HttpOnly 속성 검증 추가
- 보다 실제 사용 환경에 가까운 테스트 구조로 개선

## Test plan
- [x] CookieUtil 테스트 메서드가 올바르게 작동하는지 확인
- [x] Set-Cookie 헤더의 모든 필수 속성이 검증되는지 확인
- [x] 기존 기능과의 호환성 확인

🤖 Generated with [Claude Code](https://claude.ai/code)