### PR TITLE
[FIX] 익명 댓글 카운팅 로직 개선 및 버그 해결

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/comment/application/AnonymousAllocationResult.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/AnonymousAllocationResult.java
@@ -1,0 +1,10 @@
+package com.cotato.kampus.domain.comment.application;
+
+public record AnonymousAllocationResult(
+	Integer anonymousNumber,
+	boolean needsIncrement
+) {
+	public static AnonymousAllocationResult of(Integer anonymousNumber, boolean needsIncrement) {
+		return new AnonymousAllocationResult(anonymousNumber, needsIncrement);
+	}
+}

--- a/src/main/java/com/cotato/kampus/domain/comment/application/AnonymousNumberAllocator.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/AnonymousNumberAllocator.java
@@ -21,19 +21,23 @@ import lombok.RequiredArgsConstructor;
 public class AnonymousNumberAllocator {
 
 	private final CommentRepository commentRepository;
-	private final PostUpdater postUpdater;
 
-	public Integer allocateAnonymousNumber(Post post, UserDto userDto){
+	public AnonymousAllocationResult allocateAnonymousNumber(Post post, UserDto userDto, boolean isAuthor){
 		// 작성자가 아닌 경우에만 익명 번호 증가
-		if(!post.getUserId().equals(userDto.id())) {
-			// 해당 Post에 현재 User의 댓글 작성 여부 확인
-			Optional<Comment> comment = commentRepository.findFirstByPostIdAndUserId(
-				post.getId(), userDto.id()
-			);
-			return comment.map(Comment::getAnonymousNumber)
-				.orElseGet(() -> (postUpdater.increaseAnonymousCount(post)).getAnonymousCount());
+		if(!isAuthor) {
+			// 기존 댓글작성 여부 확인
+			Optional<Comment> comment = commentRepository.findFirstByPostIdAndUserId(post.getId(), userDto.id());
+
+			if (comment.isPresent()) {
+				// 기존 댓글이 있으면, 번호만 반환. 카운터 증가 필요 없음(false)
+				return AnonymousAllocationResult.of(comment.get().getAnonymousNumber(), false);
+			} else {
+				// 첫 댓글이면, 새 번호를 계산하고 카운터 증가 필요함(true)
+				return AnonymousAllocationResult.of(post.getAnonymousCount() + 1, true);
+			}
 		} else {
-			return null;
+			// 글쓴이면, 익명 번호 없고 카운터 증가도 필요 없음(false)
+			return AnonymousAllocationResult.of(null, false);
 		}
 	}
 

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
@@ -45,28 +45,43 @@ public class CommentService {
 	private final BoardFinder boardFinder;
 	private final PostScrapFinder postScrapFinder;
 
+	/**
+	 18    * 게시글에 새로운 댓글을 생성하고 관련 카운터를 업데이트
+	 19    *
+	 20    *@param postId   댓글을 작성할 게시글 ID
+	 21    *@param content  댓글 내용
+	 22    *@param parentId 부모 댓글 ID (대댓글이 아닐 경우 null)
+	 23    *@param targetId 답글 대상 댓글 ID (대댓글이 아닐 경우 null)
+	 24    *@return 생성된 댓글 ID
+	 25    */
 	@Transactional
-	public Long createComment(Long postId, String content, Long parentId, Long targetId) {
-		// 유저, 게시글 조회
+	public Long createComment(Long postId, String content, Long parentId, Long targetId) { // targetId는 답글 대상
 		UserDto userDto = apiUserResolver.getCurrentUserDto();
 		Post post = postFinder.find(postId);
 
-		// 학생 인증 확인
 		userValidator.validateStudentVerification(userDto);
-
-		// 부모 댓글 유효성 체크
 		commentValidator.validateParent(postId, parentId);
 
-		// 익명 번호 할당
-		Integer anonymousNumber = anonymousNumberAllocator.allocateAnonymousNumber(post, userDto);
+		boolean isAuthor = post.getUserId().equals(userDto.id());
+		AnonymousAllocationResult allocationResult = anonymousNumberAllocator.allocateAnonymousNumber(post, userDto, isAuthor);
 
-		// 댓글 추가
-		Long commentId = commentAppender.append(postId, content, anonymousNumber, parentId, targetId);
+		Long commentId = commentAppender.append(postId, content, allocationResult.anonymousNumber(), parentId, targetId);
 
-		// 게시글의 댓글 수 + 1
-		postUpdater.increaseCommentCount(post);
+		updatePostCountersForNewComment(post, allocationResult);
 
 		return commentId;
+	}
+
+	/**
+	 * 새 댓글 생성 후 게시글의 카운터를 업데이트
+	 * 새로운 익명 댓글 작성 시 익명 카운터도 함께 증가
+	 */
+	private Post updatePostCountersForNewComment(Post post, AnonymousAllocationResult result) {
+		if (result.needsIncrement()) {
+			return postUpdater.increaseCommentAndAnonymousCount(post);
+		} else {
+			return postUpdater.increaseCommentCount(post);
+		}
 	}
 
 	@Transactional
@@ -87,7 +102,6 @@ public class CommentService {
 		Post post = postFinder.find(commentDto.postId());
 
 		postUpdater.decreaseCommentCount(post);
-
 
 		// 댓글 좋아요 데이터 삭제
 		commentLikeDeleter.deleteAllByCommentId(commentId);

--- a/src/main/java/com/cotato/kampus/domain/post/domain/CardNewsPost.java
+++ b/src/main/java/com/cotato/kampus/domain/post/domain/CardNewsPost.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 @Getter
 public class CardNewsPost extends Post {
 
-	@Builder(access = AccessLevel.PRIVATE)
-	private CardNewsPost(
+	@Builder(access = AccessLevel.PACKAGE)
+	CardNewsPost(
 		Long id,
 		Long boardId,
 		Long userId,

--- a/src/main/java/com/cotato/kampus/domain/post/domain/NormalPost.java
+++ b/src/main/java/com/cotato/kampus/domain/post/domain/NormalPost.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 @Getter
 public class NormalPost extends Post {
 
-	@Builder(access = AccessLevel.PRIVATE)
-	private NormalPost(
+	@Builder(access = AccessLevel.PACKAGE)
+	NormalPost(
 		Long id,
 		Long boardId,
 		Long userId,

--- a/src/main/java/com/cotato/kampus/domain/post/domain/Post.java
+++ b/src/main/java/com/cotato/kampus/domain/post/domain/Post.java
@@ -76,6 +76,11 @@ public abstract class Post {
 			this.likeCount, this.commentCount, this.scrapCount, this.anonymousCount + 1);
 	}
 
+	public Post increaseCommentAndAnonymousCount() {
+		return createCopy(this.title, this.content, this.anonymity, this.postStatus,
+			this.likeCount, this.commentCount + 1, this.scrapCount, this.anonymousCount + 1);
+	}
+
 	public void validateAuthor(Long userId) {
 		if(!this.userId.equals(userId)) {
 			throw new AppException(ErrorCode.POST_NOT_AUTHOR);

--- a/src/main/java/com/cotato/kampus/domain/post/implement/post/PostUpdater.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/post/PostUpdater.java
@@ -22,46 +22,46 @@ public class PostUpdater {
 		return postRepository.save(updatedPost);
 	}
 
-	public void increaseLikeCount(Post post) {
+	public Post increaseLikeCount(Post post) {
 		Post updatedPost = post.increaseLikeCount();
-		postRepository.save(updatedPost);
-	}
-
-	public void decreaseLikeCount(Post post) {
-		Post updatedPost = post.decreaseLikeCount();
-		postRepository.save(updatedPost);
-	}
-
-	public void increaseCommentCount(Post post){
-		Post updatedPost = post.increaseCommentCount();
-		postRepository.save(updatedPost);
-	}
-
-	public void decreaseCommentCount(Post post){
-		Post updatedPost = post.decreaseCommentCount();
-		postRepository.save(updatedPost);
-	}
-
-	public Post increaseAnonymousCount(Post post) {
-		Post updatedPost = post.increaseAnonymousCount();
 		return postRepository.save(updatedPost);
 	}
 
-	public void increaseScrapCount(Post post) {
+	public Post decreaseLikeCount(Post post) {
+		Post updatedPost = post.decreaseLikeCount();
+		return postRepository.save(updatedPost);
+	}
+
+	public Post increaseCommentCount(Post post){
+		Post updatedPost = post.increaseCommentCount();
+		return postRepository.save(updatedPost);
+	}
+
+	public Post decreaseCommentCount(Post post){
+		Post updatedPost = post.decreaseCommentCount();
+		return postRepository.save(updatedPost);
+	}
+
+	public Post increaseCommentAndAnonymousCount(Post post) {
+		Post updatedPost = post.increaseCommentAndAnonymousCount();
+		return postRepository.save(updatedPost);
+	}
+
+	public Post increaseScrapCount(Post post) {
 		Post updatedPost = post.increaseScrapCount();
-		postRepository.save(updatedPost);
+		return postRepository.save(updatedPost);
 	}
 
-	public void decreaseScrapCount(Post post) {
+	public Post decreaseScrapCount(Post post) {
 		Post updatedPost = post.decreaseScrapCount();
-		postRepository.save(updatedPost);
+		return postRepository.save(updatedPost);
 	}
 
-	public void pendingAllByBoardId(Long boardId) {
-		postRepository.updateStatusByBoardIdAndCurrentStatus(boardId, PostStatus.PUBLISHED, PostStatus.PENDING);
+	public int pendingAllByBoardId(Long boardId) {
+		return postRepository.updateStatusByBoardIdAndCurrentStatus(boardId, PostStatus.PUBLISHED, PostStatus.PENDING);
 	}
 
-	public void revertPendingAllByBoardId(Long boardId) {
-		postRepository.updateStatusByBoardIdAndCurrentStatus(boardId, PostStatus.PENDING, PostStatus.PUBLISHED);
+	public int revertPendingAllByBoardId(Long boardId) {
+		return postRepository.updateStatusByBoardIdAndCurrentStatus(boardId, PostStatus.PENDING, PostStatus.PUBLISHED);
 	}
 }

--- a/src/test/java/com/cotato/kampus/domain/comment/application/AnonymousNumberAllocatorTest.java
+++ b/src/test/java/com/cotato/kampus/domain/comment/application/AnonymousNumberAllocatorTest.java
@@ -1,0 +1,102 @@
+package com.cotato.kampus.domain.comment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.cotato.kampus.domain.comment.dao.CommentRepository;
+import com.cotato.kampus.domain.comment.domain.Comment;
+import com.cotato.kampus.domain.post.domain.Post;
+import com.cotato.kampus.domain.post.domain.TestPostHelper;
+import com.cotato.kampus.domain.user.dto.UserDto;
+import com.cotato.kampus.domain.user.enums.UserRole;
+import com.cotato.kampus.helper.TestUserHelper;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AnonymousNumberAllocatorTest {
+
+    @InjectMocks
+    private AnonymousNumberAllocator anonymousNumberAllocator;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private Comment mockComment;
+
+    @Test
+    @DisplayName("작성자일 경우 익명번호 null과 증가 필요 없음(false) 반환")
+    void allocateAnonymousNumber_forAuthor() {
+        // given
+        Long userId = 1L;
+        Long universityId = 1L;
+        UserDto authorDto = TestUserHelper.createUserDto(userId, universityId, UserRole.VERIFIED);
+        Post mockPost = new TestPostHelper()
+            .withUserId(authorDto.id())
+            .createNormalPost();
+        boolean isAuthor = true;
+
+        // when
+        AnonymousAllocationResult result = anonymousNumberAllocator.allocateAnonymousNumber(mockPost, authorDto, isAuthor);
+
+        // then
+        assertThat(result.anonymousNumber()).isNull();
+        assertThat(result.needsIncrement()).isFalse();
+    }
+
+    @Test
+    @DisplayName("새로운 사용자일 경우 다음 번호와 함께 증가 필요(true) 반환")
+    void allocateAnonymousNumber_forNewUser() {
+        // given
+        Long authorId = 1L;
+        Long commenterId = 2L;
+        Long universityId = 1L;
+        UserDto commenterDto = TestUserHelper.createUserDto(commenterId, universityId, UserRole.VERIFIED);
+        Post mockPost = new TestPostHelper()
+            .withUserId(authorId)
+            .withAnonymousCount(2) // 현재 익명 카운트: 2
+            .createNormalPost();
+        boolean isAuthor = false;
+
+        given(commentRepository.findFirstByPostIdAndUserId(anyLong(), anyLong())).willReturn(Optional.empty());
+
+        // when
+        AnonymousAllocationResult result = anonymousNumberAllocator.allocateAnonymousNumber(mockPost, commenterDto, isAuthor);
+
+        // then
+        assertThat(result.anonymousNumber()).isEqualTo(3); // 2 + 1
+        assertThat(result.needsIncrement()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기존 사용자일 경우 기존 번호와 증가 불필요(false) 반환")
+    void allocateAnonymousNumber_forExistingUser() {
+        // given
+        Long authorId = 1L;
+        Long commenterId = 2L;
+        Long universityId = 1L;
+        UserDto commenterDto = TestUserHelper.createUserDto(commenterId, universityId, UserRole.VERIFIED);
+        Post mockPost = new TestPostHelper()
+            .withUserId(authorId)
+            .withAnonymousCount(1) // 현재 익명 카운트: 1
+            .createNormalPost();
+        boolean isAuthor = false;
+
+        given(commentRepository.findFirstByPostIdAndUserId(anyLong(), anyLong())).willReturn(Optional.of(mockComment));
+        given(mockComment.getAnonymousNumber()).willReturn(1);
+
+        // when
+        AnonymousAllocationResult result = anonymousNumberAllocator.allocateAnonymousNumber(mockPost, commenterDto, isAuthor);
+
+        // then
+        assertThat(result.anonymousNumber()).isEqualTo(1);
+        assertThat(result.needsIncrement()).isFalse();
+    }
+}

--- a/src/test/java/com/cotato/kampus/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/comment/application/CommentServiceTest.java
@@ -1,0 +1,117 @@
+package com.cotato.kampus.domain.comment.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.cotato.kampus.domain.common.application.ApiUserResolver;
+import com.cotato.kampus.domain.post.domain.Post;
+import com.cotato.kampus.domain.post.domain.TestPostHelper;
+import com.cotato.kampus.domain.post.implement.post.PostFinder;
+import com.cotato.kampus.domain.post.implement.post.PostUpdater;
+import com.cotato.kampus.domain.user.application.UserValidator;
+import com.cotato.kampus.domain.user.dto.UserDto;
+import com.cotato.kampus.domain.user.enums.UserRole;
+import com.cotato.kampus.helper.TestUserHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Mock
+    private UserValidator userValidator;
+    @Mock
+    private CommentValidator commentValidator;
+    @Mock
+    private ApiUserResolver apiUserResolver;
+    @Mock
+    private PostFinder postFinder;
+    @Mock
+    private AnonymousNumberAllocator anonymousNumberAllocator;
+    @Mock
+    private CommentAppender commentAppender;
+    @Mock
+    private PostUpdater postUpdater;
+
+    @Test
+    @DisplayName("새로운 사용자 댓글 작성: 두 카운터 모두 증가시키는 메서드 호출")
+    void createComment_forNewUser() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        Long commenterId = 2L;
+        Long universityId = 1L;
+        UserDto commenter = TestUserHelper.createUserDto(commenterId, universityId, UserRole.VERIFIED);
+
+        Post post = new TestPostHelper().withUserId(authorId).createNormalPost(); // 글쓴이 ID : 1
+
+        given(apiUserResolver.getCurrentUserDto()).willReturn(commenter);
+        given(postFinder.find(postId)).willReturn(post);
+        given(anonymousNumberAllocator.allocateAnonymousNumber(any(Post.class), any(UserDto.class), anyBoolean()))
+            .willReturn(new AnonymousAllocationResult(1, true)); // needsIncrement = true
+
+        // when
+        commentService.createComment(postId, "첫 댓글입니다", null, null);
+
+        // then
+        verify(postUpdater).increaseCommentAndAnonymousCount(any(Post.class));
+        verify(postUpdater, never()).increaseCommentCount(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("글쓴이 댓글 작성: 댓글 카운터만 증가시키는 메서드 호출")
+    void createComment_forAuthor() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        Long universityId = 1L;
+        UserDto author = TestUserHelper.createUserDto(authorId, universityId, UserRole.VERIFIED);
+        Post post = new TestPostHelper().withUserId(author.id()).createNormalPost();
+
+        given(apiUserResolver.getCurrentUserDto()).willReturn(author);
+        given(postFinder.find(postId)).willReturn(post);
+        given(anonymousNumberAllocator.allocateAnonymousNumber(any(Post.class), any(UserDto.class), anyBoolean()))
+            .willReturn(new AnonymousAllocationResult(null, false)); // needsIncrement = false
+
+        // when
+        commentService.createComment(postId, "제 글입니다", null, null);
+
+        // then
+        verify(postUpdater, never()).increaseCommentAndAnonymousCount(any(Post.class));
+        verify(postUpdater).increaseCommentCount(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("기존 사용자 댓글 작성: 댓글 카운터만 증가시키는 메서드 호출")
+    void createComment_forExistingUser() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        Long commenterId = 2L;
+        Long universityId = 1L;
+        UserDto commenter = TestUserHelper.createUserDto(commenterId, universityId, UserRole.VERIFIED);
+        Post post = new TestPostHelper().withUserId(authorId).createNormalPost();
+
+        given(apiUserResolver.getCurrentUserDto()).willReturn(commenter);
+        given(postFinder.find(postId)).willReturn(post);
+        given(anonymousNumberAllocator.allocateAnonymousNumber(any(Post.class), any(UserDto.class), anyBoolean()))
+            .willReturn(new AnonymousAllocationResult(1, false)); // needsIncrement = false
+
+        // when
+        commentService.createComment(postId, "또 왔어요", null, null);
+
+        // then
+        verify(postUpdater, never()).increaseCommentAndAnonymousCount(any(Post.class));
+        verify(postUpdater).increaseCommentCount(any(Post.class));
+    }
+}

--- a/src/test/java/com/cotato/kampus/domain/post/domain/TestPostHelper.java
+++ b/src/test/java/com/cotato/kampus/domain/post/domain/TestPostHelper.java
@@ -1,0 +1,78 @@
+package com.cotato.kampus.domain.post.domain;
+
+import com.cotato.kampus.domain.common.enums.Anonymity;
+import com.cotato.kampus.domain.post.enums.PostStatus;
+import java.time.LocalDateTime;
+
+public class TestPostHelper {
+
+    private Long id = 1L;
+    private Long boardId = 1L;
+    private Long userId = 1L;
+    private String title = "test title";
+    private String content = "test content";
+    private PostStatus postStatus = PostStatus.PUBLISHED;
+    private Anonymity anonymity = Anonymity.ANONYMOUS;
+    private int likeCount = 0;
+    private int commentCount = 0;
+    private int scrapCount = 0;
+    private int anonymousCount = 0;
+
+    public TestPostHelper withId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public TestPostHelper withUserId(Long userId) {
+        this.userId = userId;
+        return this;
+    }
+
+    public TestPostHelper withCommentCount(int commentCount) {
+        this.commentCount = commentCount;
+        return this;
+    }
+
+    public TestPostHelper withAnonymousCount(int anonymousCount) {
+        this.anonymousCount = anonymousCount;
+        return this;
+    }
+
+    public Post createNormalPost() {
+        return new NormalPost(
+            this.id,
+            this.boardId,
+            this.userId,
+            this.title,
+            this.content,
+            this.postStatus,
+            this.anonymity,
+            this.likeCount,
+            this.commentCount,
+            this.scrapCount,
+            this.anonymousCount,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+    }
+
+    public Post createCardNewsPost() {
+        return new CardNewsPost(
+            this.id,
+            this.boardId,
+            this.userId,
+            this.title,
+            this.content,
+            this.postStatus,
+            this.anonymity,
+            this.likeCount,
+            this.commentCount,
+            this.scrapCount,
+            this.anonymousCount,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+    }
+
+
+}


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
게시글에 새로운 사용자가 댓글을 달 때 `anonymousCount`가 증가하지 않는 버그를 수정 및 테스트 코드 작성


### 버그 수정 및 리팩토링 (Commit: `b7efe9e`)
**기존 문제**: `CommentService`에서 댓글과 익명 카운터를 순차적으로 업데이트하는 과정에서, 불변 객체의 상태 참조가 유실되어 `anonymousCount`가 DB에 반영되지 않는 문제가 있었습니다.

**해결 방안**:
- `AnonymousAllocationResult` DTO를 새로 도입하여, 카운터 증가 필요 여부(`needsIncrement`)를 명시적으로 전달하도록 구조를 변경했습니다.
- `PostRepository`가 도메인 객체의 변경사항을 JPA 엔티티에 올바르게 덮어쓰도록`save` 로직을 수정했습니다.
- `CommentService`가 `Allocator`의 결과에 따라 분기하여, 카운터 업데이트 로직을 명확하게 수행하도록 리팩토링했습니다.

### 단위 테스트 추가 (Commit: `72d5495`, `b7672f8`)
- 단위 테스트에서 캡슐화된 도메인 객체를 생성하기 위해 `TestPostHelper`를 도입했습니다. (`package-private` 생성자 활용)
- `NormalPost`와 `CardNewsPost`의 생성자를 `package-private`으로 수정하여 테스트 헬퍼의 접근을 허용했습니다.
- `AnonymousNumberAllocator`의 단위 테스트를 작성했습니다.
- `CommentService`의 `createComment`의 단위 테스트를 추가했습니다.

### Issue Number or Link
Resolve #317
