### PR TITLE
[FIX] 게시글 스크랩 기능 오류 수정 및 테스트 코드 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/post/application/PostInteractionService.java
+++ b/src/main/java/com/cotato/kampus/domain/post/application/PostInteractionService.java
@@ -117,13 +117,13 @@ public class PostInteractionService {
 		Post post = postFinder.find(postId);
 		post.validatePublish();
 
-		// 스크랩 중복 검증
+		// 2. 스크랩 중복 검증
 		postValidator.validateDuplicatedScrap(postId, userId);
 
-		// 게시글 스크랩 수 추가
+		// 3. 게시글 스크랩 수 증가
 		postUpdater.increaseScrapCount(post);
 
-		// 스크랩 데이터 추가
+		// 4. 스크랩 정보 저장
 		postScrapAppender.append(postId, userId);
 	}
 
@@ -134,11 +134,13 @@ public class PostInteractionService {
 		Post post = postFinder.find(postId);
 		post.validatePublish();
 
-		// 게시글 스크랩 수 감소
+		// 2. 스크랩 정보 조회
+		PostScrap postScrap = postScrapFinder.find(userId, postId);
+
+		// 3. 게시글 스크랩 수 감소
 		postUpdater.decreaseScrapCount(post);
 
-		PostScrap postScrap = postScrapFinder.find(userId, postId);
-		// 스크랩 데이터 삭제
+		// 4. 스크랩 정보 삭제
 		postScrapDeleter.delete(postScrap);
 	}
 

--- a/src/main/java/com/cotato/kampus/domain/post/implement/post/PostValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/post/PostValidator.java
@@ -19,7 +19,7 @@ public class PostValidator {
 
 	public void validateDuplicatedScrap(Long postId, Long userId) {
 		// 중복 스크랩 예외처리
-		if (postScrapRepository.existsByPostIdAndUserId(userId, postId)) {
+		if (postScrapRepository.existsByPostIdAndUserId(postId, userId)) {
 			throw new AppException(ErrorCode.POST_SCRAP_DUPLICATED);
 		}
 	}

--- a/src/main/java/com/cotato/kampus/domain/post/implement/postSrcap/PostScrapFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/postSrcap/PostScrapFinder.java
@@ -25,7 +25,7 @@ public class PostScrapFinder {
 	}
 
 	public PostScrap find(Long userId, Long postId) {
-		PostScrap postScrap = postScrapRepository.findByPostIdAndUserId(userId, postId)
+		PostScrap postScrap = postScrapRepository.findByPostIdAndUserId(postId, userId)
 			.orElseThrow(() -> new AppException(ErrorCode.POST_SCRAP_NOT_EXIST));
 
 		return postScrap;

--- a/src/test/java/com/cotato/kampus/domain/post/application/PostInteractionServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/post/application/PostInteractionServiceTest.java
@@ -1,0 +1,129 @@
+package com.cotato.kampus.domain.post.application;
+
+import com.cotato.kampus.domain.common.application.ApiUserResolver;
+import com.cotato.kampus.domain.post.domain.Post;
+import com.cotato.kampus.domain.post.domain.PostScrap;
+import com.cotato.kampus.domain.post.domain.TestPostHelper;
+import com.cotato.kampus.domain.post.implement.post.PostFinder;
+import com.cotato.kampus.domain.post.implement.post.PostUpdater;
+import com.cotato.kampus.domain.post.implement.post.PostValidator;
+import com.cotato.kampus.domain.post.implement.postSrcap.PostScrapAppender;
+import com.cotato.kampus.domain.post.implement.postSrcap.PostScrapDeleter;
+import com.cotato.kampus.domain.post.implement.postSrcap.PostScrapFinder;
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.AppException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostInteractionServiceTest {
+
+    @InjectMocks
+    private PostInteractionService postInteractionService;
+
+    @Mock
+    private ApiUserResolver apiUserResolver;
+    @Mock
+    private PostFinder postFinder;
+    @Mock
+    private PostUpdater postUpdater;
+    @Mock
+    private PostValidator postValidator;
+    @Mock
+    private PostScrapAppender postScrapAppender;
+    @Mock
+    private PostScrapFinder postScrapFinder;
+    @Mock
+    private PostScrapDeleter postScrapDeleter;
+
+    private final Long postId = 1L;
+    private final Long userId = 1L;
+
+    @Test
+    @DisplayName("게시글 스크랩 성공")
+    void scrapPost_success() {
+        // given
+        Post post = new TestPostHelper().createNormalPost();
+        given(apiUserResolver.getCurrentUserId()).willReturn(userId);
+        given(postFinder.find(postId)).willReturn(post);
+        doNothing().when(postValidator).validateDuplicatedScrap(postId, userId);
+        when(postUpdater.increaseScrapCount(post)).thenReturn(post);
+        doNothing().when(postScrapAppender).append(postId, userId);
+
+        // when
+        postInteractionService.scrapPost(postId);
+
+        // then
+        verify(postValidator).validateDuplicatedScrap(postId, userId);
+        verify(postUpdater).increaseScrapCount(post);
+        verify(postScrapAppender).append(postId, userId);
+    }
+
+    @Test
+    @DisplayName("게시글 스크랩 실패 - 이미 스크랩한 경우")
+    void scrapPost_fail_alreadyScrapped() {
+        // given
+        Post post = new TestPostHelper().createNormalPost();
+        given(apiUserResolver.getCurrentUserId()).willReturn(userId);
+        given(postFinder.find(postId)).willReturn(post);
+        doThrow(new AppException(ErrorCode.POST_SCRAP_DUPLICATED))
+                .when(postValidator).validateDuplicatedScrap(postId, userId);
+
+        // when & then
+        AppException exception = assertThrows(AppException.class,
+                () -> postInteractionService.scrapPost(postId));
+        assertEquals(ErrorCode.POST_SCRAP_DUPLICATED, exception.getErrorCode());
+
+        verify(postUpdater, never()).increaseScrapCount(any(Post.class));
+        verify(postScrapAppender, never()).append(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("게시글 스크랩 취소 성공")
+    void unscrapPost_success() {
+        // given
+        Post post = new TestPostHelper().createNormalPost();
+        PostScrap postScrap = new PostScrap(1L, post.getId(), userId);
+        given(apiUserResolver.getCurrentUserId()).willReturn(userId);
+        given(postFinder.find(postId)).willReturn(post);
+        given(postScrapFinder.find(userId, postId)).willReturn(postScrap);
+        when(postUpdater.decreaseScrapCount(post)).thenReturn(post);
+        doNothing().when(postScrapDeleter).delete(postScrap);
+
+        // when
+        postInteractionService.unscrapPost(postId);
+
+        // then
+        verify(postScrapFinder).find(userId, postId);
+        verify(postUpdater).decreaseScrapCount(post);
+        verify(postScrapDeleter).delete(postScrap);
+    }
+
+    @Test
+    @DisplayName("게시글 스크랩 취소 실패 - 스크랩하지 않은 경우")
+    void unscrapPost_fail_notScrapped() {
+        // given
+        Post post = new TestPostHelper().createNormalPost();
+        given(apiUserResolver.getCurrentUserId()).willReturn(userId);
+        given(postFinder.find(postId)).willReturn(post);
+        given(postScrapFinder.find(userId, postId))
+                .willThrow(new AppException(ErrorCode.POST_SCRAP_NOT_EXIST));
+
+        // when & then
+        AppException exception = assertThrows(AppException.class,
+                () -> postInteractionService.unscrapPost(postId));
+        assertEquals(ErrorCode.POST_SCRAP_NOT_EXIST, exception.getErrorCode());
+
+        verify(postUpdater, never()).decreaseScrapCount(any(Post.class));
+        verify(postScrapDeleter, never()).delete(any(PostScrap.class));
+    }
+}


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
게시글 스크랩/취소 기능의 파라미터 전달 오류 수정
`PostInteractionService` 의 스크랩/스크랩취소 단위 테스트 작성

### 상세 내용(Describe your changes)
- **Fix**: PostValidator와 PostScrapFinder에서 memberId, postId 파라미터 전달 순서가 잘못되던 오류를 수정했습니다. (41ea37d)
- **Refactor**: 스크랩/스크랩 취소 메서드의 주석 가독성을 개선했습니다. (5ded4c1)
- **Test**: PostInteractionService 단위 테스트를 추가했습니다. (e824256)


### Issue Number or Link
Resolve #319 