### PR TITLE
[FIX] 게시글 정렬 파라미터 이름 불일치 문제 해결

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/post/enums/PostSortType.java
+++ b/src/main/java/com/cotato/kampus/domain/post/enums/PostSortType.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum PostSortType {
 	recent("createdTime", Sort.Direction.DESC),    // 최신순
 	old("createdTime", Sort.Direction.ASC),        // 오래된순
-	likes("likeCount", Sort.Direction.DESC);           // 좋아요순
+	likeCount("likeCount", Sort.Direction.DESC);           // 좋아요순
 
 	private final String property;
 	private final Sort.Direction direction;


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
API 요청 파라미터(sort=likeCount)와 서버의 Enum 이름(likes)이 일치하지 않아 발생하던 500 에러를 해결

### 상세 내용(Describe your changes)
PostSortType Enum의 상수 이름을 likes에서 likeCount로 변경하여, API 명세 및 클라이언트 요청과 일치시켰습니다.

### Issue Number or Link
Resolve #321 