### PR TITLE
[FEATURE] 회원가입 플로우에 기본 즐겨찾기 게시판 추가 로직 구현

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardFavoriteRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardFavoriteRepositoryImpl.java
@@ -46,4 +46,12 @@ public class BoardFavoriteRepositoryImpl implements BoardFavoriteRepository {
 		BoardFavoriteEntity boardFavoriteEntity = BoardFavoriteEntity.fromDomain(boardFavorite);
 		boardFavoriteJpaRepository.delete(boardFavoriteEntity);
 	}
+
+	@Override
+	public void saveAll(List<BoardFavorite> boardFavorites) {
+		List<BoardFavoriteEntity> boardFavoriteEntities = boardFavorites.stream()
+			.map(BoardFavoriteEntity::fromDomain)
+			.toList();
+		boardFavoriteJpaRepository.saveAll(boardFavoriteEntities);
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.cotato.kampus.domain.board.dao.entity.BoardEntity;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
@@ -29,4 +31,7 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 	List<BoardEntity> findAllByBoardStatus(BoardStatus boardStatus);
 
 	boolean existsByBoardType(BoardType boardType);
+
+	@Query("SELECT b.id FROM BoardEntity b WHERE b.boardType IN :boardTypes")
+	List<Long> findBoardIdsByBoardTypeIn(@Param("boardTypes") List<BoardType> boardTypes);
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
@@ -104,4 +104,9 @@ public class BoardRepositoryImpl implements BoardRepository {
 	public boolean existsByBoardType(BoardType boardType) {
 		return boardJpaRepository.existsByBoardType(boardType);
 	}
+
+	@Override
+	public List<Long> findBoardIdsByBoardTypeIn(List<BoardType> boardTypes) {
+		return boardJpaRepository.findBoardIdsByBoardTypeIn(boardTypes);
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -85,4 +85,8 @@ public class BoardFinder {
 		return expiredBoards.stream().map(Board::getId).toList();
 	}
 
+	public List<Long> findDefaultFavoriteBoardIds() {
+		List<BoardType> targetTypes = List.of(BoardType.FIXED, BoardType.CARDNEWS);
+		return boardRepository.findBoardIdsByBoardTypeIn(targetTypes);
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/boardFavorite/BoardFavoriteManager.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/boardFavorite/BoardFavoriteManager.java
@@ -1,5 +1,7 @@
 package com.cotato.kampus.domain.board.implement.boardFavorite;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,5 +30,17 @@ public class BoardFavoriteManager {
 	@Transactional
 	public void deleteFavoriteBoard(BoardFavorite boardFavorite) {
 		boardFavoriteRepository.delete(boardFavorite);
+	}
+
+	@Transactional
+	public void appendAll(Long userId, List<Long> boardIds) {
+		List<BoardFavorite> boardFavorites = boardIds.stream()
+			.map(boardId -> BoardFavorite.builder()
+				.userId(userId)
+				.boardId(boardId)
+				.build()
+			).toList();
+
+		boardFavoriteRepository.saveAll(boardFavorites);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardFavoriteRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardFavoriteRepository.java
@@ -19,4 +19,6 @@ public interface BoardFavoriteRepository {
 	Optional<BoardFavorite> findByUserIdAndBoardId(Long userId, Long boardId);
 
 	void delete(BoardFavorite boardFavorite);
+
+	void saveAll(List<BoardFavorite> boardFavorites);
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
@@ -35,4 +35,6 @@ public interface BoardRepository{
 	List<Board> findAllByBoardStatus(BoardStatus boardStatus);
 
 	boolean existsByBoardType(BoardType boardType);
+
+	List<Long> findBoardIdsByBoardTypeIn(List<BoardType> boardTypes);
 }

--- a/src/main/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserService.java
@@ -26,7 +26,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	private final UserRepository userRepository;
 	private final BoardFinder boardFinder;
-	private final BoardFavoriteService boardFavoriteService;
 	private final BoardFavoriteManager boardFavoriteManager;
 
 	@Override
@@ -46,7 +45,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		return new CustomOAuth2User(OAuthUserRequest);
 	}
 
-	private User saveOrUpdate(OAuth2Attribute attribute, String uniqueId) {
+		User saveOrUpdate(OAuth2Attribute attribute, String uniqueId) {
 		Optional<User> optionalUser = userRepository.findByUniqueId(uniqueId);
 
 		User user;

--- a/src/main/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserService.java
@@ -1,26 +1,36 @@
 package com.cotato.kampus.global.auth.oauth.service;
 
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.stereotype.Service;
-
+import com.cotato.kampus.domain.board.application.BoardFavoriteService;
+import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.implement.board.BoardFinder;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteManager;
 import com.cotato.kampus.domain.user.dao.UserRepository;
 import com.cotato.kampus.domain.user.domain.User;
 import com.cotato.kampus.global.auth.oauth.service.dto.CustomOAuth2User;
 import com.cotato.kampus.global.auth.oauth.service.dto.OAuth2Attribute;
 import com.cotato.kampus.global.auth.oauth.service.dto.OAuthUserRequest;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	private final UserRepository userRepository;
+	private final BoardFinder boardFinder;
+	private final BoardFavoriteService boardFavoriteService;
+	private final BoardFavoriteManager boardFavoriteManager;
 
 	@Override
+	@Transactional
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
 		OAuth2User oAuth2User = super.loadUser(userRequest);
@@ -37,9 +47,17 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	}
 
 	private User saveOrUpdate(OAuth2Attribute attribute, String uniqueId) {
-		User user = userRepository.findByUniqueId(uniqueId)
-			.map(entity -> entity.update(attribute.getEmail(), attribute.getUsername()))
-			.orElse(attribute.toEntity(uniqueId));
+		Optional<User> optionalUser = userRepository.findByUniqueId(uniqueId);
+
+		User user;
+		if (optionalUser.isPresent()) {
+			user = optionalUser.get().update(attribute.getEmail(), attribute.getUsername());
+		} else {
+			user = attribute.toEntity(uniqueId);
+
+			List<Long> defaultFavoriteBoardIds = boardFinder.findDefaultFavoriteBoardIds();
+			boardFavoriteManager.appendAll(user.getId(), defaultFavoriteBoardIds);
+		}
 		return userRepository.save(user);
 	}
 }

--- a/src/test/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,90 @@
+package com.cotato.kampus.global.auth.oauth.service;
+
+import com.cotato.kampus.domain.board.implement.board.BoardFinder;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteManager;
+import com.cotato.kampus.domain.user.dao.UserRepository;
+import com.cotato.kampus.domain.user.domain.User;
+import com.cotato.kampus.global.auth.oauth.service.dto.OAuth2Attribute;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @InjectMocks
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BoardFinder boardFinder;
+
+    @Mock
+    private BoardFavoriteManager boardFavoriteManager;
+
+    @DisplayName("신규 유저일 경우, 기본 즐겨찾기 게시판을 추가한다")
+    @Test
+    void saveOrUpdate_newUser_addDefaultFavorites() {
+        // given
+        String uniqueId = "uniqueId";
+        OAuth2Attribute attribute = OAuth2Attribute.builder()
+                .username("testuser")
+                .email("test@test.com")
+                .providerId("providerId")
+                .attributes(Map.of())
+                .build();
+        User newUser = attribute.toEntity(uniqueId);
+        List<Long> defaultBoardIds = List.of(1L, 2L);  // 기본으로 추가될 즐겨찾기 게시판 ID 목록
+
+        given(userRepository.findByUniqueId(uniqueId)).willReturn(Optional.empty());  // 새로운 사용자이므로 Optional.empty()를 반환하도록 설정
+        given(userRepository.save(any(User.class))).willReturn(newUser);
+        given(boardFinder.findDefaultFavoriteBoardIds()).willReturn(defaultBoardIds);
+
+        // when
+        customOAuth2UserService.saveOrUpdate(attribute, uniqueId);
+
+        // then
+        verify(boardFinder, times(1)).findDefaultFavoriteBoardIds();
+        verify(boardFavoriteManager, times(1)).appendAll(newUser.getId(), defaultBoardIds);
+    }
+
+    @DisplayName("기존 유저일 경우, 기본 즐겨찾기를 추가하지 않는다")
+    @Test
+    void saveOrUpdate_existingUser() {
+        // given
+        String uniqueId = "uniqueId";
+        OAuth2Attribute attribute = OAuth2Attribute.builder()
+                .username("testuser")
+                .email("test@test.com")
+                .providerId("providerId")
+                .attributes(Map.of())
+                .build();
+
+        User existingUser = User.builder().build();
+
+        given(userRepository.findByUniqueId(uniqueId)).willReturn(Optional.of(existingUser)); // 기존 사용자이므로 Optional.of(existingUser)를 반환하도록 설정
+        given(userRepository.save(any(User.class))).willReturn(existingUser);
+
+        // when
+        customOAuth2UserService.saveOrUpdate(attribute, uniqueId);
+
+        // then
+        verify(boardFinder, never()).findDefaultFavoriteBoardIds();
+        verify(boardFavoriteManager, never()).appendAll(anyLong(), anyList());
+    }
+}


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
신규 회원가입 시, 기본 게시판(FIXED, CARDNEWS)을 즐겨찾기에 자동으로 추가하는 기능을 구현했습니다.

### 상세 내용(Describe your changes)
   - CustomOAuth2UserService의 saveOrUpdate 메소드 로직을 수정하여, 새로운 유저가 생성될 때 기본 즐겨찾기 게시판을 추가하도록 구현했습니다.
   - 기존 BoardFinder를 활용해 BoardType이 `FIXED`, `CARDNEWS`인 게시판을 조회하고 BoardFavoriteManager를 통해 해당 게시판들을 즐겨찾기에 추가합니다.
   - `saveOrUpdate` 메서드의 테스트 코드를 작성했습니다.

### Issue Number or Link
Resolve #323 