### PR TITLE
[FIX] 신규 유저 회원가입 시 발생하는 오류 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserService.java
@@ -48,16 +48,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		User saveOrUpdate(OAuth2Attribute attribute, String uniqueId) {
 		Optional<User> optionalUser = userRepository.findByUniqueId(uniqueId);
 
-		User user;
 		if (optionalUser.isPresent()) {
-			user = optionalUser.get().update(attribute.getEmail(), attribute.getUsername());
+			User user = optionalUser.get().update(attribute.getEmail(), attribute.getUsername());
+			return userRepository.save(user);
 		} else {
-			user = attribute.toEntity(uniqueId);
+			User newUser = attribute.toEntity(uniqueId);
+			User savedUser = userRepository.save(newUser);
 
 			List<Long> defaultFavoriteBoardIds = boardFinder.findDefaultFavoriteBoardIds();
-			boardFavoriteManager.appendAll(user.getId(), defaultFavoriteBoardIds);
+			boardFavoriteManager.appendAll(savedUser.getId(), defaultFavoriteBoardIds);
+
+			return savedUser;
 		}
-		return userRepository.save(user);
 	}
 }
 

--- a/src/test/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/cotato/kampus/global/auth/oauth/service/CustomOAuth2UserServiceTest.java
@@ -42,25 +42,33 @@ class CustomOAuth2UserServiceTest {
     void saveOrUpdate_newUser_addDefaultFavorites() {
         // given
         String uniqueId = "uniqueId";
+        Long fakeUserId = 1L; // 테스트용 가짜 ID
         OAuth2Attribute attribute = OAuth2Attribute.builder()
                 .username("testuser")
                 .email("test@test.com")
                 .providerId("providerId")
                 .attributes(Map.of())
                 .build();
-        User newUser = attribute.toEntity(uniqueId);
-        List<Long> defaultBoardIds = List.of(1L, 2L);  // 기본으로 추가될 즐겨찾기 게시판 ID 목록
+        List<Long> defaultBoardIds = List.of(1L, 2L);
 
-        given(userRepository.findByUniqueId(uniqueId)).willReturn(Optional.empty());  // 새로운 사용자이므로 Optional.empty()를 반환하도록 설정
-        given(userRepository.save(any(User.class))).willReturn(newUser);
+        // save 메소드가 반환할 User 모의 객체 생성
+        User savedUser = mock(User.class);
+
+        // 모의 객체의 getId()가 가짜 ID를 반환하도록 설정
+        given(savedUser.getId()).willReturn(fakeUserId);
+
+        // userRepository.save()가 호출되면 위에서 만든 모의 객체를 반환하도록 설정
+        given(userRepository.findByUniqueId(uniqueId)).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
         given(boardFinder.findDefaultFavoriteBoardIds()).willReturn(defaultBoardIds);
 
         // when
         customOAuth2UserService.saveOrUpdate(attribute, uniqueId);
 
         // then
+        // appendAll이 가짜 ID로 올바르게 호출되었는지 검증
         verify(boardFinder, times(1)).findDefaultFavoriteBoardIds();
-        verify(boardFavoriteManager, times(1)).appendAll(newUser.getId(), defaultBoardIds);
+        verify(boardFavoriteManager, times(1)).appendAll(eq(fakeUserId), eq(defaultBoardIds));
     }
 
     @DisplayName("기존 유저일 경우, 기본 즐겨찾기를 추가하지 않는다")


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
신규 가입 시, User ID가 발급되기 전에 기본 즐겨찾기 추가 로직이 실행되어 회원가입에 실패하는 버그를 수정합니다.

### 상세 내용(Describe your changes)
신규 유저 생성 시, User를 DB에 저장하기 전에 즐겨찾기 추가 로직(appendAll)이 호출되어 userId가 null인 문제가 있었습니다.
User를 먼저 저장하여 ID를 발급받은 후, 해당 ID로 즐겨찾기를 추가하도록 로직 순서를 수정했습니다.

### Issue Number or Link
Resolve #331 