### PR TITLE
[FEATURE] 특정 타입 게시판(고정, 카드뉴스, 대학) 즐겨찾기 해제 방지 구현

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/application/BoardFavoriteService.java
+++ b/src/main/java/com/cotato/kampus/domain/board/application/BoardFavoriteService.java
@@ -4,10 +4,12 @@ import org.springframework.stereotype.Service;
 
 import com.cotato.kampus.domain.board.domain.Board;
 import com.cotato.kampus.domain.board.domain.BoardFavorite;
-import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteFinder;
-import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteManager;
+import com.cotato.kampus.domain.board.enums.BoardType;
 import com.cotato.kampus.domain.board.implement.board.BoardFinder;
 import com.cotato.kampus.domain.board.implement.board.BoardValidator;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteFinder;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteManager;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteValidator;
 import com.cotato.kampus.domain.common.application.ApiUserResolver;
 import com.cotato.kampus.domain.user.dto.UserDto;
 import com.cotato.kampus.global.error.ErrorCode;
@@ -21,6 +23,7 @@ public class BoardFavoriteService {
 
 	private final BoardFinder boardFinder;
 	private final BoardValidator boardValidator;
+	private final BoardFavoriteValidator boardFavoriteValidator;
 
 	private final BoardFavoriteManager boardFavoriteManager;
 	private final ApiUserResolver apiUserResolver;
@@ -49,8 +52,14 @@ public class BoardFavoriteService {
 		// 유저 조회
 		UserDto user = apiUserResolver.getCurrentUserDto();
 
-		// 즐겨찾기 조회/삭제
+		// 즐겨찾기 조회
 		BoardFavorite boardFavorite = boardFavoriteFinder.findByUserIdAndBoardId(user.id(), boardId);
+
+		// 게시판 타입 조회 및 검증
+		BoardType boardType = boardFinder.findBoardType(boardId);
+		boardFavoriteValidator.validateRemovable(boardType);
+
+		// 즐겨찾기 삭제
 		boardFavoriteManager.deleteFavoriteBoard(boardFavorite);
 
 		return boardId;

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -37,4 +37,7 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 
 	@Query("SELECT b.id FROM BoardEntity b WHERE b.universityId = :universityId")
 	Optional<Long> findBoardIdByUniversityId(@Param("universityId") Long universityId);
+
+	@Query("SELECT b.boardType FROM BoardEntity b WHERE b.id = :boardId")
+	Optional<String> findBoardTypeByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
@@ -114,4 +114,9 @@ public class BoardRepositoryImpl implements BoardRepository {
 	public Optional<Long> findBoardIdByUniversityId(Long universityId) {
 		return boardJpaRepository.findBoardIdByUniversityId(universityId);
 	}
+
+	@Override
+	public Optional<String> findBoardTypeByBoardId(Long boardId) {
+		return boardJpaRepository.findBoardTypeByBoardId(boardId);
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -94,4 +94,9 @@ public class BoardFinder {
 		return boardRepository.findBoardIdByUniversityId(universityId)
 			.orElse(null);
 	}
+
+	public BoardType findBoardType(Long boardId) {
+		return BoardType.valueOf(boardRepository.findBoardTypeByBoardId(boardId)
+			.orElseThrow(() -> new AppException(ErrorCode.BOARD_NOT_FOUND)));
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/boardFavorite/BoardFavoriteValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/boardFavorite/BoardFavoriteValidator.java
@@ -1,0 +1,16 @@
+package com.cotato.kampus.domain.board.implement.boardFavorite;
+
+import com.cotato.kampus.domain.board.enums.BoardType;
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.AppException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BoardFavoriteValidator {
+
+    public void validateRemovable(BoardType boardType) {
+        if (boardType == BoardType.FIXED || boardType == BoardType.CARDNEWS || boardType == BoardType.UNIVERSITY) {
+            throw new AppException(ErrorCode.CANNOT_REMOVE_FAVORITE_BOARD);
+        }
+    }
+}

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
@@ -39,4 +39,6 @@ public interface BoardRepository{
 	List<Long> findBoardIdsByBoardTypeIn(List<BoardType> boardTypes);
 
 	Optional<Long> findBoardIdByUniversityId(Long universityId);
+
+	Optional<String> findBoardTypeByBoardId(Long boardId);
 }

--- a/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
+++ b/src/main/java/com/cotato/kampus/global/error/ErrorCode.java
@@ -122,6 +122,7 @@ public enum ErrorCode {
 	BOARD_NOT_ACTIVE(HttpStatus.FORBIDDEN, "게시판이 활성화되지 않았습니다.", "BOARD-012"),
 	BOARD_UNIVERSITY_ID_REQUIRED(HttpStatus.BAD_REQUEST, "대학 게시판은 대학 ID가 필수입니다.", "BOARD-013"),
 	DUPLICATED_UNIQUE_BOARD_TYPE(HttpStatus.BAD_REQUEST, "중복 생성이 허용되지 않는 게시판 타입입니다.", "BOARD-014"),
+	CANNOT_REMOVE_FAVORITE_BOARD(HttpStatus.BAD_REQUEST, "고정 게시판은 즐겨찾기를 해제할 수 없습니다.", "BOARD-015"),
 
 	// Product
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다.", "PRODUCT-001"),

--- a/src/test/java/com/cotato/kampus/domain/board/application/BoardFavoriteServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/board/application/BoardFavoriteServiceTest.java
@@ -1,0 +1,95 @@
+package com.cotato.kampus.domain.board.application;
+
+import com.cotato.kampus.domain.board.domain.BoardFavorite;
+import com.cotato.kampus.domain.board.enums.BoardType;
+import com.cotato.kampus.domain.board.implement.board.BoardFinder;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteFinder;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteManager;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteValidator;
+import com.cotato.kampus.domain.common.application.ApiUserResolver;
+import com.cotato.kampus.domain.user.dto.UserDto;
+import com.cotato.kampus.domain.user.enums.UserRole;
+import com.cotato.kampus.global.error.ErrorCode;
+import com.cotato.kampus.global.error.exception.AppException;
+import com.cotato.kampus.helper.TestUserHelper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BoardFavoriteServiceTest {
+
+    @InjectMocks
+    private BoardFavoriteService boardFavoriteService;
+
+    @Mock
+    private ApiUserResolver apiUserResolver;
+
+    @Mock
+    private BoardFinder boardFinder;
+
+    @Mock
+    private BoardFavoriteValidator boardFavoriteValidator;
+
+    @Mock
+    private BoardFavoriteFinder boardFavoriteFinder;
+
+    @Mock
+    private BoardFavoriteManager boardFavoriteManager;
+
+    private final UserDto user = TestUserHelper.createUserDto(1L, 401L, UserRole.VERIFIED);
+    private final Long boardId = 1L;
+
+    @Test
+    @DisplayName("게시판 즐겨찾기 해제 성공")
+    void removeFavoriteBoard_Success() {
+        // given
+        BoardFavorite boardFavorite = BoardFavorite.builder().build();
+        given(apiUserResolver.getCurrentUserDto()).willReturn(user);
+        given(boardFinder.findBoardType(boardId)).willReturn(BoardType.NORMAL);
+        given(boardFavoriteFinder.findByUserIdAndBoardId(user.id(), boardId)).willReturn(boardFavorite);
+        willDoNothing().given(boardFavoriteValidator).validateRemovable(BoardType.NORMAL);
+        willDoNothing().given(boardFavoriteManager).deleteFavoriteBoard(boardFavorite);
+
+        // when
+        Long removedBoardId = boardFavoriteService.removeFavoriteBoard(boardId);
+
+        // then
+        assertThat(removedBoardId).isEqualTo(boardId);
+        verify(apiUserResolver, times(1)).getCurrentUserDto();
+        verify(boardFinder, times(1)).findBoardType(boardId);
+        verify(boardFavoriteValidator, times(1)).validateRemovable(BoardType.NORMAL);
+        verify(boardFavoriteFinder, times(1)).findByUserIdAndBoardId(user.id(), boardId);
+        verify(boardFavoriteManager, times(1)).deleteFavoriteBoard(boardFavorite);
+    }
+
+    @Test
+    @DisplayName("고정 게시판은 즐겨찾기 해제할 수 없어 실패한다")
+    void removeFavoriteBoard_Fail_CannotRemove() {
+        // given
+        given(apiUserResolver.getCurrentUserDto()).willReturn(user);
+        given(boardFinder.findBoardType(boardId)).willReturn(BoardType.FIXED);
+        given(boardFavoriteFinder.findByUserIdAndBoardId(user.id(), boardId)).willReturn(BoardFavorite.builder().build());
+        doThrow(new AppException(ErrorCode.CANNOT_REMOVE_FAVORITE_BOARD))
+                .when(boardFavoriteValidator).validateRemovable(eq(BoardType.FIXED));
+
+        // when & then
+        AppException exception = assertThrows(AppException.class,
+                () -> boardFavoriteService.removeFavoriteBoard(boardId));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CANNOT_REMOVE_FAVORITE_BOARD);
+        verify(apiUserResolver, times(1)).getCurrentUserDto();
+        verify(boardFinder, times(1)).findBoardType(boardId);
+        verify(boardFavoriteValidator, times(1)).validateRemovable(BoardType.FIXED);
+        verify(boardFavoriteFinder, times(1)).findByUserIdAndBoardId(user.id(), boardId);
+        verify(boardFavoriteManager, never()).deleteFavoriteBoard(any(BoardFavorite.class));
+    }
+}


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
고정, 카드뉴스, 대학 게시판과 같이 즐겨찾기 해제가 불가능한 게시판에 대한 유효성 검증 로직을 추가하고, 관련 단위 테스트를 작성했습니다.

### 상세 내용(Describe your changes)
- BoardFavoriteValidator를 생성하여 즐겨찾기 해제 가능 여부를 검증
- BoardFavoriteService의 removeFavoriteBoard 메소드에 검증 로직을 적용
- 검증 실패 시 CANNOT_REMOVE_FAVORITE_BOARD 에러 코드를 반환하도록 ErrorCode에 추가
- BoardFavoriteService의 removeFavoriteBoard 메소드에 대한 성공 및 실패 케이스 단위 테스트 추가

### Issue Number or Link
Resolve #326 