### PR TITLE
refactor(IT-Cotato#328): 홈 화면 즐겨찾는 게시판 미리보기 조회 로직 개선

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
+++ b/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
@@ -63,13 +63,15 @@ public class BoardService {
 		// 유저 조회
 		Long userId = apiUserResolver.getCurrentUserId();
 
-		// 즐겨찾는 게시판 조회
-		List<Long> favoriteBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userId);
-		Map<Long, Board> boards = boardFinder.findBoardMap(favoriteBoardIds);
+		// 미리보기에 필요한 즐겨찾기 게시판 목록 조회
+		List<Board> boardsForPreview = boardFinder.findFavoriteBoardsForPreview(userId);
+		List<Long> boardIds = boardsForPreview.stream().map(Board::getId).toList();
 
-		Map<Long, Optional<Post>> latestPosts = postFinder.findTopPosts(favoriteBoardIds);
+		// 게시판별 최신 게시글 조회
+		Map<Long, Post> latestPosts = postFinder.findLatestPostsByBoardIds(boardIds);
 
-		return postDtoMapper.toHomePostThumbnails(boards, latestPosts);
+		// Board 목록과 Post 매핑
+		return postDtoMapper.toHomePostThumbnails(boardsForPreview, latestPosts);
 	}
 
 	public List<HomePostThumbnail> getUniversityBoardPreview() {

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -2,14 +2,12 @@ package com.cotato.kampus.domain.board.implement.board;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteFinder;
 import com.cotato.kampus.domain.board.implement.port.BoardRepository;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
 import com.cotato.kampus.domain.board.enums.BoardType;
@@ -24,7 +22,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardFinder {
 
+	private static final List<BoardType> EXCLUDED_BOARD_TYPES_FOR_FAVORITE_PREVIEW = List.of(
+		BoardType.CARDNEWS,
+		BoardType.TRENDING
+	);
+
 	private final BoardRepository boardRepository;
+	private final BoardFavoriteFinder boardFavoriteFinder;
 
 	public List<Board> findAllBoards(BoardStatus boardStatus) {
 		List<Board> boards;
@@ -43,16 +47,13 @@ public class BoardFinder {
 		return boards;
 	}
 
-	public List<Board> findBoardsWithIds(List<Long> boardIds) {
-		return boardRepository.findAllByIdIn(boardIds);
-	}
+	public List<Board> findFavoriteBoardsForPreview(Long userId) {
+		List<Long> favoritesBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userId);
+		List<Board> favoriteBoards = boardRepository.findAllByIdIn(favoritesBoardIds);
 
-	public Map<Long, Board> findBoardMap(List<Long> boardIds) {
-		return findBoardsWithIds(boardIds).stream()
-			.collect(Collectors.toMap(
-				Board::getId,
-				Function.identity()
-			));
+		return favoriteBoards.stream()
+			.filter(board -> !EXCLUDED_BOARD_TYPES_FOR_FAVORITE_PREVIEW.contains(board.getBoardType()))
+			.toList();
 	}
 
 	public List<Board> findPublicBoards() {

--- a/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostJpaRepository.java
@@ -65,7 +65,15 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
 	Slice<PostEntity> findAllAccessiblePostsByIds(@Param("postIds") List<Long> postIds, @Param("userUnivId") Long userUnivId,
 		Pageable pageable);
 
-	Optional<PostEntity> findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus);
+	@Query(value = """
+		SELECT p.* FROM (
+				SELECT *, ROW_NUMBER() OVER(PARTITION BY board_id ORDER BY created_time DESC) as rn 
+			    FROM post 
+			    WHERE board_id IN :boardIds AND post_status = :postStatus
+		) p 
+		WHERE p.rn = 1
+	    """, nativeQuery = true)
+	List<PostEntity> findLatestPostPerBoard(@Param("boardIds") List<Long> boardIds, @Param("postStatus") String postStatus);
 	
 	Slice<PostEntity> findByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus, Pageable pageable);
 

--- a/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostRepositoryImpl.java
@@ -100,9 +100,10 @@ public class PostRepositoryImpl implements PostRepository {
 	}
 
 	@Override
-	public Optional<Post> findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus) {
-		return postJpaRepository.findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(boardId, postStatus)
-			.map(PostEntity::toDomain);
+	public List<Post> findLatestPostPerBoard(List<Long> boardIds, String postStatus) {
+		return postJpaRepository.findLatestPostPerBoard(boardIds, postStatus).stream()
+			.map(PostEntity::toDomain)
+			.toList();
 	}
 
 	@Override

--- a/src/main/java/com/cotato/kampus/domain/post/implement/port/PostRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/port/PostRepository.java
@@ -49,7 +49,7 @@ public interface PostRepository {
 		Pageable pageable);
 
 	// 게시판의 최신 게시글 1개 조회
-	Optional<Post> findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus);
+	List<Post> findLatestPostPerBoard(List<Long> boardId, String postStatus);
 
 	// 게시판 게시글 페이징 조회 (최신순)
 	Slice<Post> findByBoardIdAndPostStatusOrderByCreatedTimeDesc(Long boardId, PostStatus postStatus, Pageable pageable);

--- a/src/main/java/com/cotato/kampus/domain/post/implement/post/PostDtoMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/post/PostDtoMapper.java
@@ -2,7 +2,6 @@ package com.cotato.kampus.domain.post.implement.post;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
@@ -70,14 +69,12 @@ public class PostDtoMapper {
 	}
 
 	public List<HomePostThumbnail> toHomePostThumbnails(
-		Map<Long, Board> boards,
-		Map<Long, Optional<Post>> postsByBoardId
+		List<Board> boards,
+		Map<Long, Post> postsByBoardId
 	) {
-		return boards.entrySet().stream()
-			.map(entry -> {
-				Long boardId = entry.getKey();
-				Board board = entry.getValue();
-				Post post = postsByBoardId.getOrDefault(boardId, Optional.empty()).orElse(null);
+		return boards.stream()
+			.map(board ->{
+				Post post = postsByBoardId.get(board.getId());
 				return HomePostThumbnail.from(board, post);
 			})
 			.toList();

--- a/src/main/java/com/cotato/kampus/domain/post/implement/post/PostFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/post/PostFinder.java
@@ -64,12 +64,10 @@ public class PostFinder {
 			.getContent();
 	}
 
-	public Map<Long, Optional<Post>> findTopPosts(List<Long> boardIds) {
-		return boardIds.stream()
-			.collect(Collectors.toMap(
-				Function.identity(), // boardId
-				boardId -> postRepository.findTopByBoardIdAndPostStatusOrderByCreatedTimeDesc(boardId, PostStatus.PUBLISHED)
-			));
+	public Map<Long, Post> findLatestPostsByBoardIds(List<Long> boardIds) {
+		List<Post> latestPosts = postRepository.findLatestPostPerBoard(boardIds, PostStatus.PUBLISHED.name());
+		return latestPosts.stream()
+				.collect(Collectors.toMap(Post::getBoardId, Function.identity()));
 	}
 
 	public List<Post> findTop5ByBoardId(Long boardId) {


### PR DESCRIPTION
- 기존 N+1 쿼리 문제 해결
- 카드뉴스 및 트렌딩 게시판은 미리보기 목록에서 제외하도록 로직을 변경

---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
홈 화면의 즐겨찾는 게시판 미리보기 조회 시 발생하던 N+1 쿼리 문제를 해결하고, 특정 게시판 타입(CARDNEWS, TRENDING)을 제외하도록 로직을 개선합니다.

### 상세 내용(Describe your changes)
 - **N+1 쿼리 문제 해결**: `PostRepository`에 `findLatestPostPerBoard` 메서드를 추가하여, 여러 게시판의 최신 게시글을 한 번의 쿼리로 효율적으로 조회하도록 수정
 
- **미리보기 로직 변경**: `BoardFinder`에서 카드뉴스 및 트렌딩 타입의 게시판을 필터링하는 로직을 추가하여, 홈 화면 미리보기에 불필요한 게시판이 노출되지 않도록 변경

### Issue Number or Link
Resolve #327 