### PR TITLE
[FIX] 게시글 스크랩 기능 오류 수정 및 테스트 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/post/application/PostService.java
+++ b/src/main/java/com/cotato/kampus/domain/post/application/PostService.java
@@ -213,7 +213,7 @@ public class PostService {
 
 		boolean isAuthor = post.getUserId().equals(userId);
 		boolean isLiked = postLikeFinder.hasUserLikedPost(userId, postId);
-		boolean isScrapped = postScrapFinder.isPostScrappedByUser(userId, postId);
+		boolean isScrapped = postScrapFinder.isPostScrappedByUser(postId, userId);
 		return PostDetails.of(post, board, categories, postPhotos, isAuthor, isLiked, isScrapped);
 	}
 

--- a/src/main/java/com/cotato/kampus/domain/post/implement/postSrcap/PostScrapFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/postSrcap/PostScrapFinder.java
@@ -20,8 +20,8 @@ public class PostScrapFinder {
 
 	private final PostScrapRepository postScrapRepository;
 
-	public boolean isPostScrappedByUser(Long userId, Long postId) {
-		return postScrapRepository.existsByPostIdAndUserId(userId, postId);
+	public boolean isPostScrappedByUser(Long postId, Long userId) {
+		return postScrapRepository.existsByPostIdAndUserId(postId, userId);
 	}
 
 	public PostScrap find(Long userId, Long postId) {

--- a/src/test/java/com/cotato/kampus/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/post/application/PostServiceTest.java
@@ -1,0 +1,104 @@
+package com.cotato.kampus.domain.post.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.domain.TestBoardHelper;
+import com.cotato.kampus.domain.board.enums.BoardStatus;
+import com.cotato.kampus.domain.board.implement.board.BoardFinder;
+import com.cotato.kampus.domain.category.implement.CategoryFinder;
+import com.cotato.kampus.domain.common.application.ApiUserResolver;
+import com.cotato.kampus.domain.post.domain.Post;
+import com.cotato.kampus.domain.post.domain.PostDetails;
+import com.cotato.kampus.domain.post.domain.TestPostHelper;
+import com.cotato.kampus.domain.post.implement.post.PostFinder;
+import com.cotato.kampus.domain.post.implement.postCategory.PostCategoryFinder;
+import com.cotato.kampus.domain.post.implement.postImage.PostPhotoFinder;
+import com.cotato.kampus.domain.post.implement.postLike.PostLikeFinder;
+import com.cotato.kampus.domain.post.implement.postSrcap.PostScrapFinder;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+	@InjectMocks
+	private PostService postService;
+
+	@Mock
+	private ApiUserResolver apiUserResolver;
+
+	@Mock
+	private PostFinder postFinder;
+
+	@Mock
+	private BoardFinder boardFinder;
+
+	@Mock
+	private PostPhotoFinder postPhotoFinder;
+
+	@Mock
+	private PostCategoryFinder postCategoryFinder;
+
+	@Mock
+	private CategoryFinder categoryFinder;
+
+	@Mock
+	private PostLikeFinder postLikeFinder;
+
+	@Mock
+	private PostScrapFinder postScrapFinder;
+
+	@Test
+	@DisplayName("게시글 상세 조회 시 모든 의존성이 올바르게 호출된다")
+	void findPostDetail_Success() {
+		// given
+		Long postId = 1L;
+		Long userId = 100L;
+
+		Post post = new TestPostHelper()
+			.withId(postId)
+			.withUserId(userId)
+			.createNormalPost();
+
+		Board board = TestBoardHelper.createNormalBoard(
+			post.getBoardId(),
+			false,
+			BoardStatus.ACTIVE);
+
+		List<Long> categoryIds = List.of();
+
+		given(apiUserResolver.getCurrentUserId()).willReturn(userId);
+		given(postFinder.find(postId)).willReturn(post);
+		given(boardFinder.findBoard(post.getBoardId())).willReturn(board);
+		given(postPhotoFinder.findPostPhotos(postId)).willReturn(List.of());
+		given(postCategoryFinder.findCategoryIdsByPostId(postId)).willReturn(List.of());
+		given(categoryFinder.findAllByIds(categoryIds)).willReturn(List.of());
+		given(postScrapFinder.isPostScrappedByUser(postId, userId)).willReturn(true);
+		given(postLikeFinder.hasUserLikedPost(userId, postId)).willReturn(false);
+
+		// when
+		PostDetails result = postService.findPostDetail(postId);
+
+		// then
+		assertThat(result).isNotNull();
+		then(apiUserResolver).should().getCurrentUserId();
+		then(postFinder).should().find(postId);
+		then(boardFinder).should().findBoard(post.getBoardId());
+		then(postPhotoFinder).should().findPostPhotos(postId);
+		then(postCategoryFinder).should().findCategoryIdsByPostId(postId);
+		then(categoryFinder).should().findAllByIds(categoryIds);
+		then(postLikeFinder).should().hasUserLikedPost(userId, postId);
+		then(postScrapFinder).should().isPostScrappedByUser(postId, userId);
+	}
+}


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
게시글 상세 조회 시, 사용자의 스크랩 여부가 올바르게 표시되지 않는 버그를 수정하고, 재발 방지를 위한 단위 테스트를 추가했습니다.

### 상세 내용(Describe your changes)
**원인**
스크랩 여부를 확인하는 PostScrapFinder.isPostScrappedByUser 메서드를 호출할 때, userId와 postId 파라미터의 순서가 바뀌어 전달되어 항상 false를 반환하는 문제가 있었습니다.

**해결**
메서드 호출부에서 userId와 postId를 올바른 순서로 전달하도록 수정했습니다.

### Issue Number or Link
Resolve #337 
