### PR TITLE
[FIX] 댓글 익명 번호 중복 할당 오류 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
@@ -23,14 +23,9 @@ public class CommentDeleter {
 
 	@Transactional
 	public void delete(Long commentId) {
-		// 대댓글이 있으면 삭제된 상태로 업데이트
-		if (commentRepository.existsByParentId(commentId)) {
-			Comment comment = commentFinder.findComment(commentId);
-			comment.setCommentStatus(CommentStatus.DELETED_BY_USER);
-		}
-
-		// 댓글 삭제
-		commentRepository.deleteById(commentId);
+		// 삭제된 상태로 업데이트
+		Comment comment = commentFinder.findComment(commentId);
+		comment.setCommentStatus(CommentStatus.DELETED_BY_USER);
 	}
 
 	@Transactional

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
@@ -7,7 +7,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.comment.dao.CommentRepository;
 import com.cotato.kampus.domain.comment.domain.Comment;
+import com.cotato.kampus.domain.comment.dto.CommentDto;
 import com.cotato.kampus.domain.comment.enums.CommentStatus;
+import com.cotato.kampus.domain.post.domain.Post;
+import com.cotato.kampus.domain.post.implement.post.PostFinder;
+import com.cotato.kampus.domain.post.implement.post.PostUpdater;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +24,25 @@ public class CommentDeleter {
 	private final CommentRepository commentRepository;
 	private final CommentFinder commentFinder;
 	private final CommentLikeDeleter commentLikeDeleter;
+	private final PostFinder postFinder;
+	private final PostUpdater postUpdater;
 
 	@Transactional
-	public void delete(Long commentId) {
-		// 삭제된 상태로 업데이트
-		Comment comment = commentFinder.findComment(commentId);
+	public void delete(CommentDto commentDto) {
+		// 대댓글이 없는 댓글이 삭제될 때만 게시글의 전체 댓글 수를 감소시킨다
+		// 대댓글이 있다면 "삭제된 댓글입니다"로 내용만 마스킹 처리되므로 전체 댓글 수는 유지된다
+		boolean hasReplies = commentRepository.existsByParentId(commentDto.commentId());
+		if(!hasReplies) {
+			Post post = postFinder.find(commentDto.postId());
+			postUpdater.decreaseCommentCount(post);
+		}
+
+		// 댓글을 논리적으로 삭제 처리한다
+		Comment comment = commentFinder.findComment(commentDto.commentId());
 		comment.setCommentStatus(CommentStatus.DELETED_BY_USER);
+
+		// 댓글 좋아요 삭제 처리한다
+		commentLikeDeleter.deleteAllByCommentId(commentDto.commentId());
 	}
 
 	@Transactional

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
@@ -1,6 +1,7 @@
 package com.cotato.kampus.domain.comment.application;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,9 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.comment.dao.CommentLikeRepository;
-import com.cotato.kampus.domain.comment.domain.Comment;
 import com.cotato.kampus.domain.comment.dto.CommentDetail;
 import com.cotato.kampus.domain.comment.dto.CommentDto;
+import com.cotato.kampus.domain.comment.enums.CommentStatus;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -25,38 +26,54 @@ public class CommentMapper {
 	private final CommentLikeRepository commentLikeRepository;
 	private final CommentFinder commentFinder;
 
-	public List<CommentDetail> buildCommentHierarchy(List<CommentDto> commentDtos, Long userId){
+	public List<CommentDetail> buildCommentHierarchy(List<CommentDto> allCommentDtos, Long userId){
 		Map<Long, CommentDetail> commentMap = new HashMap<>();
-		List<CommentDetail> rootComments = new ArrayList<>();
 
+		// 모든 댓글을 CommentDetail 객체로 변환하여 Map에 저장
+		for (CommentDto dto : allCommentDtos) {
+			String targetAuthor = (dto.targetId() != null) ?
+				anonymousNumberAllocator.resolveAuthorName(commentFinder.findCommentDto(dto.targetId())) : null;
 
-		// 모든 댓글을 Map으로 변환
-		for (CommentDto commentDto : commentDtos) {
-			String targetAuthor = null;
-			if(commentDto.targetId() != null) {
-				CommentDto targetCommentDto = commentFinder.findCommentDto(commentDto.targetId());
-				targetAuthor = anonymousNumberAllocator.resolveAuthorName(targetCommentDto);
-			}
 			CommentDetail detail = CommentDetail.of(
-				commentDto,
-				anonymousNumberAllocator.resolveAuthorName(commentDto),
+				dto,
+				anonymousNumberAllocator.resolveAuthorName(dto),
 				targetAuthor,
 				new ArrayList<>(),
-				commentLikeRepository.existsByUserIdAndCommentId(userId, commentDto.commentId())
+				commentLikeRepository.existsByUserIdAndCommentId(userId, dto.commentId())
 			);
-			commentMap.put(commentDto.commentId(), detail);
+			commentMap.put(dto.commentId(), detail);
 		}
 
 		// 부모-자식 관계 형성
-		for(CommentDto commentDto : commentDtos){
-			if(commentDto.parentId() == null){
-				rootComments.add(commentMap.get(commentDto.commentId()));
-			} else {
-				CommentDetail parent = commentMap.get(commentDto.parentId());
-				parent.replies().add(commentMap.get(commentDto.commentId()));
-
+		for (CommentDetail detail : commentMap.values()) {
+			if(detail.parentId() != null) {
+				CommentDetail parent = commentMap.get(detail.parentId());
+				if(parent != null) {
+					parent.replies().add(detail);
+				}
 			}
 		}
+
+		// 최종 필터링 및 내용 변경
+		List<CommentDetail> rootComments = new ArrayList<>();
+		for(CommentDetail detail : commentMap.values()) {
+			// 최상위 댓글 대상으로 필터링 시작
+			if(detail.parentId() == null) {
+				boolean isDeleted = detail.commentStatus() != CommentStatus.NORMAL;
+				boolean hasReplies = !detail.replies().isEmpty();
+
+				if (isDeleted && hasReplies) {
+					// 삭제됐지만 대댓글이 있는 경우: 내용 변경 후 추가
+					rootComments.add(detail.withMaskedContent());
+				} else if (!isDeleted) {
+					rootComments.add(detail);
+				}
+				// 삭제됐고 대댓글도 없는 경우는 아무것도 하지 않음 (결과에서 제외)
+			}
+		}
+
+		rootComments.sort(Comparator.comparing(CommentDetail::createdTime));
+
 		return rootComments;
 	}
 

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
@@ -92,8 +92,9 @@ public class CommentService {
 		// 댓글 조회
 		CommentDto commentDto = commentFinder.findCommentDto(commentId);
 
-		// 작성자 검증
+		// 유효성 검증
 		commentValidator.validateCommentAuthor(userId, commentDto);
+		commentValidator.validateCommentStatus(commentId);
 
 		// 댓글 상태 업데이트
 		commentDeleter.delete(commentId);

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
@@ -95,16 +95,13 @@ public class CommentService {
 		// 작성자 검증
 		commentValidator.validateCommentAuthor(userId, commentDto);
 
-		// 댓글 삭제
+		// 댓글 상태 업데이트
 		commentDeleter.delete(commentId);
 
 		// 게시글의 댓글 수 - 1
 		Post post = postFinder.find(commentDto.postId());
 
 		postUpdater.decreaseCommentCount(post);
-
-		// 댓글 좋아요 데이터 삭제
-		commentLikeDeleter.deleteAllByCommentId(commentId);
 	}
 
 	@Transactional

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.board.domain.Board;
 import com.cotato.kampus.domain.board.implement.board.BoardFinder;
+import com.cotato.kampus.domain.comment.dao.CommentRepository;
 import com.cotato.kampus.domain.comment.dto.CommentDetail;
 import com.cotato.kampus.domain.comment.dto.CommentDto;
 import com.cotato.kampus.domain.common.application.ApiUserResolver;
@@ -86,23 +87,16 @@ public class CommentService {
 
 	@Transactional
 	public void deleteComment(Long commentId) {
-		// 유저 조회
+		// 1. 유저, 댓글 확인
 		Long userId = apiUserResolver.getCurrentUserId();
-
-		// 댓글 조회
 		CommentDto commentDto = commentFinder.findCommentDto(commentId);
 
-		// 유효성 검증
+		// 2. 댓글을 삭제할 수 있는 권한과 상태인지 검증
 		commentValidator.validateCommentAuthor(userId, commentDto);
 		commentValidator.validateCommentStatus(commentId);
 
-		// 댓글 상태 업데이트
-		commentDeleter.delete(commentId);
-
-		// 게시글의 댓글 수 - 1
-		Post post = postFinder.find(commentDto.postId());
-
-		postUpdater.decreaseCommentCount(post);
+		// 3. 댓글 삭제의 모든 후속 처리를 Deleter에게 위임
+		commentDeleter.delete(commentDto);
 	}
 
 	@Transactional

--- a/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
@@ -52,4 +52,19 @@ public record CommentDetail(
 			replies
 		);
 	}
+
+	public CommentDetail withMaskedContent() {
+		return new CommentDetail(
+			this.commentId,
+			this.parentId,
+			this.targetAuthor,
+			this.commentStatus,
+			this.author,
+			"삭제된 댓글입니다.",
+			this.likes,
+			this.isLiked,
+			this.createdTime,
+			this.replies
+		);
+	}
 }

--- a/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
@@ -60,7 +60,7 @@ public record CommentDetail(
 			this.targetAuthor,
 			this.commentStatus,
 			this.author,
-			"삭제된 댓글입니다.",
+			"This comment was deleted.",
 			this.likes,
 			this.isLiked,
 			this.createdTime,


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
대댓글이 있는 댓글을 삭제할 때 발생하는 문제를 해결하고, 삭제 로직을 개선합니다.

### 상세 내용(Describe your changes)
- 대댓글이 존재하는 댓글을 삭제할 경우, 실제 데이터를 삭제하는 대신 "This comment was deleted." 라는 메시지로 내용을 마스킹 처리하도록 변경했습니다.
- 대댓글이 없는 댓글은 기존과 동일하게 삭제 처리되며, 게시글의 전체 댓글 수가 정상적으로 감소합니다.
- 댓글 삭제 시, 해당 댓글에 연결된 좋아요 데이터도 함께 삭제되도록 로직을 수정했습니다.
- 댓글 계층 구조를 만드는 로직(`CommentMapper`)과 삭제 로직(`CommentDeleter`, `CommentService`)을 전반적으로 리팩토링했습니다.

### Issue Number or Link
Resolve #339 