### PR TITLE
[FIX] 재학생 인증 유저 대학 게시판 제공 및 성능 개선

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/api/BoardController.java
+++ b/src/main/java/com/cotato/kampus/domain/board/api/BoardController.java
@@ -26,7 +26,7 @@ public class BoardController {
 	private final BoardService boardService;
 
 	@GetMapping("/public")
-	@Operation(summary = "공용 게시판 목록 조회", description = "공용 게시판 목록을 조회합니다. (학교 게시판 제외)")
+	@Operation(summary = "전체 게시판 목록 조회", description = "전체 게시판 목록을 조회합니다. 인증된 유저는 학교 게시판(존재하는 경우)을 포함하여 반환합니다.")
 	public ResponseEntity<DataResponse<BoardListResponse>> getBoardList() {
 		return ResponseEntity.ok(DataResponse.from(
 			BoardListResponse.from(

--- a/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
+++ b/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
@@ -20,10 +20,21 @@ import com.cotato.kampus.domain.post.domain.Post;
 import com.cotato.kampus.domain.post.implement.post.PostDtoMapper;
 import com.cotato.kampus.domain.post.implement.post.PostFinder;
 import com.cotato.kampus.domain.post.implement.trendingPost.TrendingPostFinder;
+import com.cotato.kampus.domain.user.application.UserFinder;
 import com.cotato.kampus.domain.user.application.UserValidator;
+import com.cotato.kampus.domain.user.domain.User;
 import com.cotato.kampus.domain.user.dto.UserDto;
-
+import com.cotato.kampus.domain.user.enums.UserRole;
+import com.cotato.kampus.domain.user.enums.VerificationStatus;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -41,13 +52,18 @@ public class BoardService {
 
 	public List<BoardWithFavoriteStatus> getBoardList() {
 		// 유저 조회
-		Long userId = apiUserResolver.getCurrentUserId();
+		UserDto userDto = apiUserResolver.getCurrentUserDto();
 
-		// 즐겨찾는 게시판 조회
-		List<Long> favoriteBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userId);
+		// 즐겨찾는 게시판 id 조회
+		Set<Long> favoriteBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userDto.id());
 
 		// 공용 게시판 조회
-		List<Board> boards = boardFinder.findPublicBoards();
+		List<Board> boards = new ArrayList<>(boardFinder.findPublicBoards());
+
+		// 재학생 인증 유저일 경우, 대학 게시판 추가
+		if (userDto.userRole() == UserRole.VERIFIED) {
+			boardFinder.findByUniversityId(userDto.universityId()).ifPresent(boards::add);
+		}
 
 		// 즐겨찾기 여부 매핑
 		List<BoardWithFavoriteStatus> boardWithFavorites = new ArrayList<>(

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardFavoriteJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardFavoriteJpaRepository.java
@@ -2,8 +2,11 @@ package com.cotato.kampus.domain.board.dao.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.cotato.kampus.domain.board.dao.entity.BoardFavoriteEntity;
 
@@ -16,4 +19,7 @@ public interface BoardFavoriteJpaRepository extends JpaRepository<BoardFavoriteE
 	Optional<BoardFavoriteEntity> findByUserIdAndBoardId(Long userId, Long boardId);
 
 	void deleteByUserIdAndBoardId(Long userId, Long boardId);
+
+	@Query("SELECT bf.boardId FROM BoardFavoriteEntity bf WHERE bf.userId = :userId")
+	Set<Long> findBoardIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardFavoriteRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardFavoriteRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.cotato.kampus.domain.board.dao.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.stereotype.Repository;
 
@@ -58,5 +59,10 @@ public class BoardFavoriteRepositoryImpl implements BoardFavoriteRepository {
 	@Override
 	public void deleteByUserIdAndBoardId(Long userId, Long boardId) {
 		boardFavoriteJpaRepository.deleteByUserIdAndBoardId(userId, boardId);
+	}
+
+	@Override
+	public Set<Long> findBoardIdsByUserId(Long userId) {
+		return boardFavoriteJpaRepository.findBoardIdsByUserId(userId);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -3,6 +3,7 @@ package com.cotato.kampus.domain.board.dao.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,7 +19,7 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 
 	Optional<BoardEntity> findByUniversityId(Long universityId);
 
-	List<BoardEntity> findAllByIdIn(List<Long> ids);
+	List<BoardEntity> findAllByIdIn(Set<Long> ids);
 
 	boolean existsByUniversityId(Long universityId);
 

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.cotato.kampus.domain.board.dao.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.stereotype.Repository;
 
@@ -40,7 +41,7 @@ public class BoardRepositoryImpl implements BoardRepository {
 	}
 
 	@Override
-	public List<Board> findAllByIdIn(List<Long> ids){
+	public List<Board> findAllByIdIn(Set<Long> ids){
 		return boardJpaRepository.findAllByIdIn(ids).stream()
 			.map(BoardEntity::toDomain)
 			.toList();

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
@@ -3,6 +3,7 @@ package com.cotato.kampus.domain.board.implement.board;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +33,7 @@ public class BoardDtoMapper {
 		return BoardWithFavoriteStatus.from(board, isFavorite);
 	}
 
-	public List<BoardWithFavoriteStatus> updateFavoriteStatus(List<Board> boards, List<Long> favoriteBoardIds) {
+	public List<BoardWithFavoriteStatus> updateFavoriteStatus(List<Board> boards, Set<Long> favoriteBoardIds) {
 		return boards.stream()
 			.map(board -> BoardWithFavoriteStatus.from(board, favoriteBoardIds.contains(board.getId())
 			))

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -69,6 +69,10 @@ public class BoardFinder {
 		return board;
 	}
 
+	public Optional<Board> findByUniversityId(Long universityId) {
+		return boardRepository.findByUniversityId(universityId);
+	}
+
 	public Board findUniversityBoard(Long userUniversityId) {
 		Board board = boardRepository.findByUniversityId(userUniversityId)
 			.orElseThrow(() -> new AppException(ErrorCode.BOARD_NOT_FOUND));

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -2,6 +2,8 @@ package com.cotato.kampus.domain.board.implement.board;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,7 +50,7 @@ public class BoardFinder {
 	}
 
 	public List<Board> findFavoriteBoardsForPreview(Long userId) {
-		List<Long> favoritesBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userId);
+		Set<Long> favoritesBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userId);
 		List<Board> favoriteBoards = boardRepository.findAllByIdIn(favoritesBoardIds);
 
 		return favoriteBoards.stream()

--- a/src/main/java/com/cotato/kampus/domain/board/implement/boardFavorite/BoardFavoriteFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/boardFavorite/BoardFavoriteFinder.java
@@ -1,6 +1,6 @@
 package com.cotato.kampus.domain.board.implement.boardFavorite;
 
-import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,11 +20,8 @@ public class BoardFavoriteFinder {
 
 	private final BoardFavoriteRepository boardFavoriteRepository;
 
-	public List<Long> findFavoriteBoardIds(Long userId) {
-		return boardFavoriteRepository.findAllByUserId(userId)
-			.stream()
-			.map(BoardFavorite::getBoardId)
-			.toList();
+	public Set<Long> findFavoriteBoardIds(Long userId) {
+		return boardFavoriteRepository.findBoardIdsByUserId(userId);
 	}
 
 	public boolean existsByUserIdAndBoardId(Long userId, Long boardId) {

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardFavoriteRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardFavoriteRepository.java
@@ -2,6 +2,7 @@ package com.cotato.kampus.domain.board.implement.port;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.stereotype.Repository;
 
@@ -23,4 +24,6 @@ public interface BoardFavoriteRepository {
 	void saveAll(List<BoardFavorite> boardFavorites);
 
 	void deleteByUserIdAndBoardId(Long userId, Long boardId);
+
+	Set<Long> findBoardIdsByUserId(Long userId);
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
@@ -3,6 +3,7 @@ package com.cotato.kampus.domain.board.implement.port;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.cotato.kampus.domain.board.domain.Board;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
@@ -16,7 +17,7 @@ public interface BoardRepository{
 
 	Optional<Board> findById(Long id);
 
-	List<Board> findAllByIdIn(List<Long> boardIds);
+	List<Board> findAllByIdIn(Set<Long> boardIds);
 
 	void deleteAll(List<Board> boards);
 


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
재학생 인증을 완료한 사용자의 게시판 목록 조회 시, 소속 대학 게시판을 포함하여 반환하도록 기능을 추가하고, 즐겨찾기 게시판 조회 로직의 성능을 개선했습니다.

### 상세 내용(Describe your changes)
- 인증된 사용자인 경우, 해당 대학의 게시판(존재하는 경우)을 조회하여 전체 게시v판 목록에 추가합니다.

- 즐겨찾기 게시판 ID를 조회하고 포함 여부를 확인하는 로직에서 `List` 대신 `Set` 자료구조를 사용하도록 변경했습니다.

- 관련 Repository, Finder, Mapper 등 다수의 파일에서 메서드 시그니처를 `Set<Long>` 으로 통일했습니다.


### Issue Number or Link
Resolve #341 