### PR TITLE
[FIX] 기본 즐겨찾기 게시판에 트렌딩 게시판 누락 건 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -25,8 +25,11 @@ import lombok.RequiredArgsConstructor;
 public class BoardFinder {
 
 	private static final List<BoardType> EXCLUDED_BOARD_TYPES_FOR_FAVORITE_PREVIEW = List.of(
-		BoardType.CARDNEWS,
-		BoardType.TRENDING
+		BoardType.CARDNEWS, BoardType.TRENDING
+	);
+
+	private static final List<BoardType> DEFAULT_FAVORITE_BOARD_TYPES = List.of(
+		BoardType.FIXED, BoardType.CARDNEWS, BoardType.TRENDING
 	);
 
 	private final BoardRepository boardRepository;
@@ -93,8 +96,7 @@ public class BoardFinder {
 	}
 
 	public List<Long> findDefaultFavoriteBoardIds() {
-		List<BoardType> targetTypes = List.of(BoardType.FIXED, BoardType.CARDNEWS, BoardType.TRENDING);
-		return boardRepository.findBoardIdsByBoardTypeIn(targetTypes);
+		return boardRepository.findBoardIdsByBoardTypeIn(DEFAULT_FAVORITE_BOARD_TYPES);
 	}
 
 	public Long findUniversityBoardId(Long universityId) {

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -93,7 +93,7 @@ public class BoardFinder {
 	}
 
 	public List<Long> findDefaultFavoriteBoardIds() {
-		List<BoardType> targetTypes = List.of(BoardType.FIXED, BoardType.CARDNEWS);
+		List<BoardType> targetTypes = List.of(BoardType.FIXED, BoardType.CARDNEWS, BoardType.TRENDING);
 		return boardRepository.findBoardIdsByBoardTypeIn(targetTypes);
 	}
 

--- a/src/test/java/com/cotato/kampus/domain/board/implement/board/BoardFinderTest.java
+++ b/src/test/java/com/cotato/kampus/domain/board/implement/board/BoardFinderTest.java
@@ -1,0 +1,43 @@
+package com.cotato.kampus.domain.board.implement.board;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.kampus.domain.board.enums.BoardType;
+import com.cotato.kampus.domain.board.implement.port.BoardRepository;
+
+@ExtendWith(MockitoExtension.class)
+class BoardFinderTest {
+
+	@InjectMocks
+	private BoardFinder boardFinder;
+
+	@Mock
+	private BoardRepository boardRepository;
+
+	@Test
+	@DisplayName("기본 즐겨찾기 게시판 ID 조회 시, FIXED, CARDNEWS, TRENDING 타입을 모두 포함하여 조회한다.")
+	void findDefaultFavoriteBoardIds_Success() {
+		// given
+		List<BoardType> expectedTypes = List.of(BoardType.FIXED, BoardType.CARDNEWS, BoardType.TRENDING);
+		List<Long> expectedBoardIds = List.of(1L, 2L, 3L);
+
+		given(boardRepository.findBoardIdsByBoardTypeIn(expectedTypes)).willReturn(expectedBoardIds);
+
+		// when
+		List<Long> actualBoardIds = boardFinder.findDefaultFavoriteBoardIds();
+
+		// then
+		verify(boardRepository, times(1)).findBoardIdsByBoardTypeIn(expectedTypes);
+		assertThat(actualBoardIds).isEqualTo(expectedBoardIds);
+	}
+}

--- a/src/test/java/com/cotato/kampus/domain/board/implement/board/BoardFinderTest.java
+++ b/src/test/java/com/cotato/kampus/domain/board/implement/board/BoardFinderTest.java
@@ -1,6 +1,6 @@
 package com.cotato.kampus.domain.board.implement.board;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
@@ -8,11 +8,13 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cotato.kampus.domain.board.enums.BoardType;
+import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteFinder;
 import com.cotato.kampus.domain.board.implement.port.BoardRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +26,9 @@ class BoardFinderTest {
 	@Mock
 	private BoardRepository boardRepository;
 
+	@Mock
+	private BoardFavoriteFinder boardFavoriteFinder;
+
 	@Test
 	@DisplayName("기본 즐겨찾기 게시판 ID 조회 시, FIXED, CARDNEWS, TRENDING 타입을 모두 포함하여 조회한다.")
 	void findDefaultFavoriteBoardIds_Success() {
@@ -31,13 +36,15 @@ class BoardFinderTest {
 		List<BoardType> expectedTypes = List.of(BoardType.FIXED, BoardType.CARDNEWS, BoardType.TRENDING);
 		List<Long> expectedBoardIds = List.of(1L, 2L, 3L);
 
-		given(boardRepository.findBoardIdsByBoardTypeIn(expectedTypes)).willReturn(expectedBoardIds);
+		given(boardRepository.findBoardIdsByBoardTypeIn(anyList())).willReturn(expectedBoardIds);
 
 		// when
 		List<Long> actualBoardIds = boardFinder.findDefaultFavoriteBoardIds();
 
 		// then
-		verify(boardRepository, times(1)).findBoardIdsByBoardTypeIn(expectedTypes);
-		assertThat(actualBoardIds).isEqualTo(expectedBoardIds);
+		ArgumentCaptor<List<BoardType>> captor = ArgumentCaptor.forClass(List.class);
+		verify(boardRepository).findBoardIdsByBoardTypeIn(captor.capture());
+		assertThat(captor.getValue()).containsExactlyInAnyOrderElementsOf(expectedTypes);
+		assertThat(actualBoardIds).containsExactlyElementsOf(expectedBoardIds);
 	}
 }


### PR DESCRIPTION
- BoardFinder: 기본 게시판 조회 로직에 TRENDING 타입 추가
- BoardFinderTest: 관련 단위 테스트 코드 작성하여 로직 검증

---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
신규 유저가 회원가입 시 기본으로 추가되는 즐겨찾기 게시판 목록에 '트렌딩' 게시판이 누락되어 있어 추가합니다.

### 상세 내용(Describe your changes)
- BoardFinder: 기본 게시판 조회 로직에 TRENDING 타입 추가
- BoardFinderTest: 관련 단위 테스트 코드 작성하여 로직 검증

### Issue Number or Link
Resolve #347 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default favorite boards now include Trending alongside Fixed and Card News; new users will see Trending preselected.
* **Tests**
  * Added unit tests to verify the default favorite board types (Fixed, Card News, Trending) are used and that the expected board IDs are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->