### PR TITLE
[FIX] 관리자가 대학 게시판을 볼 수 없던 문제 해결

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
+++ b/src/main/java/com/cotato/kampus/domain/board/application/BoardService.java
@@ -61,7 +61,7 @@ public class BoardService {
 		List<Board> boards = new ArrayList<>(boardFinder.findPublicBoards());
 
 		// 재학생 인증 유저일 경우, 대학 게시판 추가
-		if (userDto.userRole() == UserRole.VERIFIED) {
+		if (userDto.userRole().canAccessUniversityBoard()) {
 			boardFinder.findByUniversityId(userDto.universityId()).ifPresent(boards::add);
 		}
 

--- a/src/main/java/com/cotato/kampus/domain/user/enums/UserRole.java
+++ b/src/main/java/com/cotato/kampus/domain/user/enums/UserRole.java
@@ -6,6 +6,6 @@ public enum UserRole {
 	UNVERIFIED;
 
 	public boolean canAccessUniversityBoard() {
-		return this == VERIFIED || this == UNVERIFIED;
+		return this == VERIFIED || this == ADMIN;
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/user/enums/UserRole.java
+++ b/src/main/java/com/cotato/kampus/domain/user/enums/UserRole.java
@@ -3,5 +3,9 @@ package com.cotato.kampus.domain.user.enums;
 public enum UserRole {
 	ADMIN,
 	VERIFIED,
-	UNVERIFIED
+	UNVERIFIED;
+
+	public boolean canAccessUniversityBoard() {
+		return this == VERIFIED || this == UNVERIFIED;
+	}
 }


### PR DESCRIPTION
- BoardService에 있던 권한 확인 로직에 ADMIN 역할을 추가
- 관련 로직을 UserRole enum 내 canAccessUniversityBoard() 메소드로 이동시켜 응집도를 높이고 유지보수성을 개선

---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
관리자(ADMIN) 계정이 대학 게시판을 조회할 수 없던 버그를 해결하고, 역할 기반 권한 확인 로직을 개선

### 상세 내용(Describe your changes)
- ADMIN 역할을 권한 목록에 포함하도록 수정

- BoardService에 있던 역할 확인 로직(userRole == VERIFIED || userRole == ADMIN)을 UserRole Enum 내부의 canAccessUniversityBoard() 메소드로 이동

### Issue Number or Link
Resolve #349 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded access to the University Board: users with additional eligible roles can now view it.
  * Boards list behavior unchanged: public boards still load, favorites are preserved, and existing sorting remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->