### PR TITLE
[FIX] Favorite 게시판에서 제외되는 타입에 UNIVERSITY 타입 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -1,6 +1,7 @@
 package com.cotato.kampus.domain.board.implement.board;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -24,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardFinder {
 
-	private static final List<BoardType> EXCLUDED_BOARD_TYPES_FOR_FAVORITE_PREVIEW = List.of(
+	private static final Set<BoardType> EXCLUDED_BOARD_TYPES_FOR_FAVORITE_PREVIEW = EnumSet.of(
 		BoardType.CARDNEWS, BoardType.TRENDING, BoardType.UNIVERSITY
 	);
 

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class BoardFinder {
 
 	private static final List<BoardType> EXCLUDED_BOARD_TYPES_FOR_FAVORITE_PREVIEW = List.of(
-		BoardType.CARDNEWS, BoardType.TRENDING
+		BoardType.CARDNEWS, BoardType.TRENDING, BoardType.UNIVERSITY
 	);
 
 	private static final List<BoardType> DEFAULT_FAVORITE_BOARD_TYPES = List.of(


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
 Favorite 게시판에서 제외되는 타입에 UNIVERSITY 타입 추가

### 상세 내용(Describe your changes)


### Issue Number or Link
Resolve #354 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Favorite preview no longer includes University boards (in addition to Cardnews and Trending), reducing irrelevant items and improving relevance.
  * Ensures only supported board types appear in the favorite preview section.

* **Chores**
  * Updated internal rules to align favorite preview behavior with current board-type policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->