### PR TITLE
[ENHANCEMENT] 관리자 게시판 목록 조회 성능 개선

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
+++ b/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
@@ -17,6 +17,7 @@ import com.cotato.kampus.domain.admin.dto.VerificationWithPhoto;
 import com.cotato.kampus.domain.admin.dto.response.AdminCardNewsThumbnail;
 import com.cotato.kampus.domain.admin.dto.BoardDetails;
 import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.domain.BoardWithPostCount;
 import com.cotato.kampus.domain.board.domain.UniversityBoard;
 import com.cotato.kampus.domain.board.implement.board.BoardAppender;
 import com.cotato.kampus.domain.board.implement.board.BoardDtoMapper;
@@ -177,7 +178,7 @@ public class AdminService {
 		userValidator.validateAdminAccess();
 
 		// 게시판 목록과 각 게시판의 게시글 수를 함께 조회
-		List<Object[]> boardsWithPostCount;
+		List<BoardWithPostCount> boardsWithPostCount;
 		if (boardStatus == null) {
 			boardsWithPostCount = boardFinder.findAllBoardsWithPostCount();
 		} else {

--- a/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
+++ b/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
@@ -176,7 +176,7 @@ public class AdminService {
 		// 관리자 검증
 		userValidator.validateAdminAccess();
 
-		// JOIN FETCH로 한 번의 쿼리로 게시판과 게시글 수를 함께 조회
+		// 게시판 목록과 각 게시판의 게시글 수를 함께 조회
 		List<Object[]> boardsWithPostCount;
 		if (boardStatus == null) {
 			boardsWithPostCount = boardFinder.findAllBoardsWithPostCount();

--- a/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
+++ b/src/main/java/com/cotato/kampus/domain/admin/application/AdminService.java
@@ -176,11 +176,16 @@ public class AdminService {
 		// 관리자 검증
 		userValidator.validateAdminAccess();
 
-		// 각 게시판의 게시글 수 매핑하여 반환
-		List<Board> boards = boardFinder.findAllBoards(boardStatus);
+		// JOIN FETCH로 한 번의 쿼리로 게시판과 게시글 수를 함께 조회
+		List<Object[]> boardsWithPostCount;
+		if (boardStatus == null) {
+			boardsWithPostCount = boardFinder.findAllBoardsWithPostCount();
+		} else {
+			boardsWithPostCount = boardFinder.findBoardsWithPostCount(boardStatus);
+		}
 
-		// 게시판 게시글 수, 삭제까지 남은 날짜 수 매핑
-		return boardDtoMapper.mapToAdminBoardDetail(boards);
+		// Board 객체와 게시글 수를 함께 받아서 바로 매핑
+		return boardDtoMapper.mapToAdminBoardDetail(boardsWithPostCount);
 	}
 
 	public BoardDetails getBoard(Long boardId) {

--- a/src/main/java/com/cotato/kampus/domain/board/dao/projection/BoardWithPostCountProjection.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/projection/BoardWithPostCountProjection.java
@@ -4,5 +4,5 @@ import com.cotato.kampus.domain.board.dao.entity.BoardEntity;
 
 public interface BoardWithPostCountProjection {
 	BoardEntity getBoard();
-	Long getPostCount();
+	long getPostCount();
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/projection/BoardWithPostCountProjection.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/projection/BoardWithPostCountProjection.java
@@ -1,0 +1,8 @@
+package com.cotato.kampus.domain.board.dao.projection;
+
+import com.cotato.kampus.domain.board.dao.entity.BoardEntity;
+
+public interface BoardWithPostCountProjection {
+	BoardEntity getBoard();
+	Long getPostCount();
+}

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -44,6 +44,6 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 	@Query("SELECT b AS board, COUNT(p) AS postCount FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardStatus = :status GROUP BY b")
 	List<BoardWithPostCountProjection> findBoardsWithPostCount(@Param("status") BoardStatus status);
 
-	@Query("SELECT b AS board, COUNT(p) AS postCount FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardType != 'CARDNEWS' GROUP BY b")
+	@Query("SELECT b AS board, COUNT(p) AS postCount FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId GROUP BY b")
 	List<BoardWithPostCountProjection> findAllBoardsWithPostCount();
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -29,8 +29,6 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 
 	List<BoardEntity> findByDeletionScheduledAtBefore(LocalDateTime now);
 
-	List<BoardEntity> findAllByBoardStatus(BoardStatus boardStatus);
-
 	boolean existsByBoardType(BoardType boardType);
 
 	@Query("SELECT b.id FROM BoardEntity b WHERE b.boardType IN :boardTypes")
@@ -41,4 +39,10 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 
 	@Query("SELECT b.boardType FROM BoardEntity b WHERE b.id = :boardId")
 	Optional<String> findBoardTypeByBoardId(@Param("boardId") Long boardId);
+
+	@Query("SELECT b, COALESCE(COUNT(p), 0) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardStatus = :status GROUP BY b")
+	List<Object[]> findBoardsWithPostCount(@Param("status") BoardStatus status);
+
+	@Query("SELECT b, COALESCE(COUNT(p), 0) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardType != 'CARDNEWS' GROUP BY b")
+	List<Object[]> findAllBoardsWithPostCount();
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -40,9 +40,9 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 	@Query("SELECT b.boardType FROM BoardEntity b WHERE b.id = :boardId")
 	Optional<String> findBoardTypeByBoardId(@Param("boardId") Long boardId);
 
-	@Query("SELECT b, COALESCE(COUNT(p), 0) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardStatus = :status GROUP BY b")
+	@Query("SELECT b, COUNT(p) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardStatus = :status GROUP BY b")
 	List<Object[]> findBoardsWithPostCount(@Param("status") BoardStatus status);
 
-	@Query("SELECT b, COALESCE(COUNT(p), 0) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardType != 'CARDNEWS' GROUP BY b")
+	@Query("SELECT b, COUNT(p) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardType != 'CARDNEWS' GROUP BY b")
 	List<Object[]> findAllBoardsWithPostCount();
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardJpaRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.cotato.kampus.domain.board.dao.entity.BoardEntity;
+import com.cotato.kampus.domain.board.dao.projection.BoardWithPostCountProjection;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
 import com.cotato.kampus.domain.board.enums.BoardType;
 
@@ -40,9 +41,9 @@ public interface BoardJpaRepository extends JpaRepository<BoardEntity, Long> {
 	@Query("SELECT b.boardType FROM BoardEntity b WHERE b.id = :boardId")
 	Optional<String> findBoardTypeByBoardId(@Param("boardId") Long boardId);
 
-	@Query("SELECT b, COUNT(p) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardStatus = :status GROUP BY b")
-	List<Object[]> findBoardsWithPostCount(@Param("status") BoardStatus status);
+	@Query("SELECT b AS board, COUNT(p) AS postCount FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardStatus = :status GROUP BY b")
+	List<BoardWithPostCountProjection> findBoardsWithPostCount(@Param("status") BoardStatus status);
 
-	@Query("SELECT b, COUNT(p) FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardType != 'CARDNEWS' GROUP BY b")
-	List<Object[]> findAllBoardsWithPostCount();
+	@Query("SELECT b AS board, COUNT(p) AS postCount FROM BoardEntity b LEFT JOIN PostEntity p ON b.id = p.boardId WHERE b.boardType != 'CARDNEWS' GROUP BY b")
+	List<BoardWithPostCountProjection> findAllBoardsWithPostCount();
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
@@ -119,10 +119,7 @@ public class BoardRepositoryImpl implements BoardRepository {
 	public List<BoardWithPostCount> findBoardsWithPostCount(BoardStatus status) {
 		List<BoardWithPostCountProjection> results = boardJpaRepository.findBoardsWithPostCount(status);
 		return results.stream()
-			.map(projection -> new BoardWithPostCount(
-				projection.getBoard().toDomain(),  // BoardEntity -> Board 변환
-				projection.getPostCount()  // 게시글 수
-			))
+			.map(BoardRepositoryImpl::toDomainRow)
 			.toList();
 	}
 
@@ -130,10 +127,11 @@ public class BoardRepositoryImpl implements BoardRepository {
 	public List<BoardWithPostCount> findAllBoardsWithPostCount() {
 		List<BoardWithPostCountProjection> results = boardJpaRepository.findAllBoardsWithPostCount();
 		return results.stream()
-			.map(projection -> new BoardWithPostCount(
-				projection.getBoard().toDomain(),  // BoardEntity -> Board 변환
-				projection.getPostCount()  // 게시글 수
-			))
+			.map(BoardRepositoryImpl::toDomainRow)
 			.toList();
+	}
+
+	private static BoardWithPostCount toDomainRow(BoardWithPostCountProjection p) {
+		return new BoardWithPostCount(p.getBoard().toDomain(), p.getPostCount());
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
@@ -8,7 +8,9 @@ import java.util.Set;
 import org.springframework.stereotype.Repository;
 
 import com.cotato.kampus.domain.board.dao.entity.BoardEntity;
+import com.cotato.kampus.domain.board.dao.projection.BoardWithPostCountProjection;
 import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.domain.BoardWithPostCount;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
 import com.cotato.kampus.domain.board.enums.BoardType;
 import com.cotato.kampus.domain.board.implement.port.BoardRepository;
@@ -114,24 +116,24 @@ public class BoardRepositoryImpl implements BoardRepository {
 	}
 
 	@Override
-	public List<Object[]> findBoardsWithPostCount(BoardStatus status) {
-		List<Object[]> results = boardJpaRepository.findBoardsWithPostCount(status);
+	public List<BoardWithPostCount> findBoardsWithPostCount(BoardStatus status) {
+		List<BoardWithPostCountProjection> results = boardJpaRepository.findBoardsWithPostCount(status);
 		return results.stream()
-			.map(arr -> new Object[] {
-				((BoardEntity) arr[0]).toDomain(),  // BoardEntity -> Board 변환
-				arr[1]  // 게시글 수는 그대로
-			})
+			.map(projection -> new BoardWithPostCount(
+				projection.getBoard().toDomain(),  // BoardEntity -> Board 변환
+				projection.getPostCount()  // 게시글 수
+			))
 			.toList();
 	}
 
 	@Override
-	public List<Object[]> findAllBoardsWithPostCount() {
-		List<Object[]> results = boardJpaRepository.findAllBoardsWithPostCount();
+	public List<BoardWithPostCount> findAllBoardsWithPostCount() {
+		List<BoardWithPostCountProjection> results = boardJpaRepository.findAllBoardsWithPostCount();
 		return results.stream()
-			.map(arr -> new Object[] {
-				((BoardEntity) arr[0]).toDomain(),  // BoardEntity -> Board 변환
-				arr[1]  // 게시글 수는 그대로
-			})
+			.map(projection -> new BoardWithPostCount(
+				projection.getBoard().toDomain(),  // BoardEntity -> Board 변환
+				projection.getPostCount()  // 게시글 수
+			))
 			.toList();
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/board/dao/repository/BoardRepositoryImpl.java
@@ -94,14 +94,6 @@ public class BoardRepositoryImpl implements BoardRepository {
 	}
 
 	@Override
-	public List<Board> findAllByBoardStatus(BoardStatus boardStatus){
-		return boardJpaRepository.findAllByBoardStatus(boardStatus)
-			.stream()
-			.map(BoardEntity::toDomain)
-			.toList();
-	}
-
-	@Override
 	public boolean existsByBoardType(BoardType boardType) {
 		return boardJpaRepository.existsByBoardType(boardType);
 	}
@@ -119,5 +111,27 @@ public class BoardRepositoryImpl implements BoardRepository {
 	@Override
 	public Optional<String> findBoardTypeByBoardId(Long boardId) {
 		return boardJpaRepository.findBoardTypeByBoardId(boardId);
+	}
+
+	@Override
+	public List<Object[]> findBoardsWithPostCount(BoardStatus status) {
+		List<Object[]> results = boardJpaRepository.findBoardsWithPostCount(status);
+		return results.stream()
+			.map(arr -> new Object[] {
+				((BoardEntity) arr[0]).toDomain(),  // BoardEntity -> Board 변환
+				arr[1]  // 게시글 수는 그대로
+			})
+			.toList();
+	}
+
+	@Override
+	public List<Object[]> findAllBoardsWithPostCount() {
+		List<Object[]> results = boardJpaRepository.findAllBoardsWithPostCount();
+		return results.stream()
+			.map(arr -> new Object[] {
+				((BoardEntity) arr[0]).toDomain(),  // BoardEntity -> Board 변환
+				arr[1]  // 게시글 수는 그대로
+			})
+			.toList();
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/domain/BoardWithPostCount.java
+++ b/src/main/java/com/cotato/kampus/domain/board/domain/BoardWithPostCount.java
@@ -1,0 +1,4 @@
+package com.cotato.kampus.domain.board.domain;
+
+public record BoardWithPostCount(Board board, Long postCount) {
+}

--- a/src/main/java/com/cotato/kampus/domain/board/domain/BoardWithPostCount.java
+++ b/src/main/java/com/cotato/kampus/domain/board/domain/BoardWithPostCount.java
@@ -1,4 +1,4 @@
 package com.cotato.kampus.domain.board.domain;
 
-public record BoardWithPostCount(Board board, Long postCount) {
+public record BoardWithPostCount(Board board, long postCount) {
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
@@ -40,15 +40,15 @@ public class BoardDtoMapper {
 			.toList();
 	}
 
-	public List<AdminBoardDetail> mapToAdminBoardDetail(List<Board> boards) {
+	public List<AdminBoardDetail> mapToAdminBoardDetail(List<Object[]> boardsWithPostCount) {
 		LocalDateTime now = LocalDateTime.now();
 
-		return boards.stream()
-			.map(board -> {
-				// 게시글 수
-				Long postCount = postFinder.countByBoardId(board.getId());
+		return boardsWithPostCount.stream()
+			.map(arr -> {
+				Board board = (Board) arr[0];
+				Long postCount = (Long) arr[1];
 
-				// 삭제 대기인 게시글은 삭제 날짜 카운트 반환
+				// 삭제 대기인 게시판은 삭제 날짜 카운트 반환
 				if (board.getBoardStatus().equals(BoardStatus.PENDING_DELETION)) {
 					// 삭제까지 남은 날짜
 					Long deletionCountDown = ChronoUnit.DAYS.between(now, board.getDeletionScheduledAt());

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
@@ -47,7 +47,7 @@ public class BoardDtoMapper {
 		return boardsWithPostCount.stream()
 			.map(boardWithPostCount -> {
 				Board board = boardWithPostCount.board();
-				Long postCount = boardWithPostCount.postCount();
+				long postCount = boardWithPostCount.postCount();
 
 				// 삭제 대기인 게시판은 삭제 날짜 카운트 반환
 				if (board.getBoardStatus().equals(BoardStatus.PENDING_DELETION)) {

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardDtoMapper.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.admin.dto.AdminBoardDetail;
 import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.domain.BoardWithPostCount;
 import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteFinder;
 import com.cotato.kampus.domain.board.domain.BoardWithFavoriteStatus;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
@@ -40,13 +41,13 @@ public class BoardDtoMapper {
 			.toList();
 	}
 
-	public List<AdminBoardDetail> mapToAdminBoardDetail(List<Object[]> boardsWithPostCount) {
+	public List<AdminBoardDetail> mapToAdminBoardDetail(List<BoardWithPostCount> boardsWithPostCount) {
 		LocalDateTime now = LocalDateTime.now();
 
 		return boardsWithPostCount.stream()
-			.map(arr -> {
-				Board board = (Board) arr[0];
-				Long postCount = (Long) arr[1];
+			.map(boardWithPostCount -> {
+				Board board = boardWithPostCount.board();
+				Long postCount = boardWithPostCount.postCount();
 
 				// 삭제 대기인 게시판은 삭제 날짜 카운트 반환
 				if (board.getBoardStatus().equals(BoardStatus.PENDING_DELETION)) {

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -36,23 +36,6 @@ public class BoardFinder {
 	private final BoardRepository boardRepository;
 	private final BoardFavoriteFinder boardFavoriteFinder;
 
-	public List<Board> findAllBoards(BoardStatus boardStatus) {
-		List<Board> boards;
-
-		// 전체 게시판 조회 (카드뉴스 제외)
-		if (boardStatus == null) {
-			boards = boardRepository.findAll().stream()
-				.filter(board -> !board.getBoardType().equals(BoardType.CARDNEWS))
-				.toList();
-		} else {
-			boards = boardRepository.findAllByBoardStatus(boardStatus).stream()
-				.filter(board -> !board.getBoardType().equals(BoardType.CARDNEWS))
-				.toList();
-		}
-
-		return boards;
-	}
-
 	public List<Board> findFavoriteBoardsForPreview(Long userId) {
 		Set<Long> favoritesBoardIds = boardFavoriteFinder.findFavoriteBoardIds(userId);
 		List<Board> favoriteBoards = boardRepository.findAllByIdIn(favoritesBoardIds);
@@ -108,5 +91,21 @@ public class BoardFinder {
 	public BoardType findBoardType(Long boardId) {
 		return BoardType.valueOf(boardRepository.findBoardTypeByBoardId(boardId)
 			.orElseThrow(() -> new AppException(ErrorCode.BOARD_NOT_FOUND)));
+	}
+
+	public List<Object[]> findAllBoardsWithPostCount() {
+		List<Object[]> results = boardRepository.findAllBoardsWithPostCount();
+		// 카드뉴스 제외 필터링
+		return results.stream()
+			.filter(arr -> !((Board) arr[0]).getBoardType().equals(BoardType.CARDNEWS))
+			.toList();
+	}
+
+	public List<Object[]> findBoardsWithPostCount(BoardStatus status) {
+		List<Object[]> results = boardRepository.findBoardsWithPostCount(status);
+		// 카드뉴스 제외 필터링
+		return results.stream()
+			.filter(arr -> !((Board) arr[0]).getBoardType().equals(BoardType.CARDNEWS))
+			.toList();
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.domain.BoardWithPostCount;
 import com.cotato.kampus.domain.board.implement.boardFavorite.BoardFavoriteFinder;
 import com.cotato.kampus.domain.board.implement.port.BoardRepository;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
@@ -97,19 +98,19 @@ public class BoardFinder {
 			.orElseThrow(() -> new AppException(ErrorCode.BOARD_NOT_FOUND)));
 	}
 
-	public List<Object[]> findAllBoardsWithPostCount() {
-		List<Object[]> results = boardRepository.findAllBoardsWithPostCount();
+	public List<BoardWithPostCount> findAllBoardsWithPostCount() {
+		List<BoardWithPostCount> results = boardRepository.findAllBoardsWithPostCount();
 		// 관리자용 제외 게시판 필터링
 		return results.stream()
-			.filter(arr -> !EXCLUDED_BOARD_TYPES_FOR_ADMIN.contains(((Board) arr[0]).getBoardType()))
+			.filter(boardWithPostCount -> !EXCLUDED_BOARD_TYPES_FOR_ADMIN.contains(boardWithPostCount.board().getBoardType()))
 			.toList();
 	}
 
-	public List<Object[]> findBoardsWithPostCount(BoardStatus status) {
-		List<Object[]> results = boardRepository.findBoardsWithPostCount(status);
+	public List<BoardWithPostCount> findBoardsWithPostCount(BoardStatus status) {
+		List<BoardWithPostCount> results = boardRepository.findBoardsWithPostCount(status);
 		// 관리자용 제외 게시판 필터링
 		return results.stream()
-			.filter(arr -> !EXCLUDED_BOARD_TYPES_FOR_ADMIN.contains(((Board) arr[0]).getBoardType()))
+			.filter(boardWithPostCount -> !EXCLUDED_BOARD_TYPES_FOR_ADMIN.contains(boardWithPostCount.board().getBoardType()))
 			.toList();
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -29,6 +29,10 @@ public class BoardFinder {
 		BoardType.CARDNEWS, BoardType.TRENDING, BoardType.UNIVERSITY
 	);
 
+	private static final List<BoardType> EXCLUDED_BOARD_TYPES_FOR_ADMIN = List.of(
+		BoardType.CARDNEWS
+	);
+
 	private static final List<BoardType> DEFAULT_FAVORITE_BOARD_TYPES = List.of(
 		BoardType.FIXED, BoardType.CARDNEWS, BoardType.TRENDING
 	);
@@ -95,17 +99,17 @@ public class BoardFinder {
 
 	public List<Object[]> findAllBoardsWithPostCount() {
 		List<Object[]> results = boardRepository.findAllBoardsWithPostCount();
-		// 카드뉴스 제외 필터링
+		// 관리자용 제외 게시판 필터링
 		return results.stream()
-			.filter(arr -> !((Board) arr[0]).getBoardType().equals(BoardType.CARDNEWS))
+			.filter(arr -> !EXCLUDED_BOARD_TYPES_FOR_ADMIN.contains(((Board) arr[0]).getBoardType()))
 			.toList();
 	}
 
 	public List<Object[]> findBoardsWithPostCount(BoardStatus status) {
 		List<Object[]> results = boardRepository.findBoardsWithPostCount(status);
-		// 카드뉴스 제외 필터링
+		// 관리자용 제외 게시판 필터링
 		return results.stream()
-			.filter(arr -> !((Board) arr[0]).getBoardType().equals(BoardType.CARDNEWS))
+			.filter(arr -> !EXCLUDED_BOARD_TYPES_FOR_ADMIN.contains(((Board) arr[0]).getBoardType()))
 			.toList();
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/board/BoardFinder.java
@@ -29,7 +29,7 @@ public class BoardFinder {
 		BoardType.CARDNEWS, BoardType.TRENDING, BoardType.UNIVERSITY
 	);
 
-	private static final List<BoardType> EXCLUDED_BOARD_TYPES_FOR_ADMIN = List.of(
+	private static final EnumSet<BoardType> EXCLUDED_BOARD_TYPES_FOR_ADMIN = EnumSet.of(
 		BoardType.CARDNEWS
 	);
 

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
@@ -33,8 +33,6 @@ public interface BoardRepository{
 
 	List<Board> findByDeletionScheduledAtBefore(LocalDateTime now);
 
-	List<Board> findAllByBoardStatus(BoardStatus boardStatus);
-
 	boolean existsByBoardType(BoardType boardType);
 
 	List<Long> findBoardIdsByBoardTypeIn(List<BoardType> boardTypes);
@@ -42,4 +40,8 @@ public interface BoardRepository{
 	Optional<Long> findBoardIdByUniversityId(Long universityId);
 
 	Optional<String> findBoardTypeByBoardId(Long boardId);
+
+	List<Object[]> findBoardsWithPostCount(BoardStatus status);
+
+	List<Object[]> findAllBoardsWithPostCount();
 }

--- a/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/board/implement/port/BoardRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.cotato.kampus.domain.board.domain.Board;
+import com.cotato.kampus.domain.board.domain.BoardWithPostCount;
 import com.cotato.kampus.domain.board.enums.BoardStatus;
 import com.cotato.kampus.domain.board.enums.BoardType;
 
@@ -41,7 +42,7 @@ public interface BoardRepository{
 
 	Optional<String> findBoardTypeByBoardId(Long boardId);
 
-	List<Object[]> findBoardsWithPostCount(BoardStatus status);
+	List<BoardWithPostCount> findBoardsWithPostCount(BoardStatus status);
 
-	List<Object[]> findAllBoardsWithPostCount();
+	List<BoardWithPostCount> findAllBoardsWithPostCount();
 }

--- a/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostJpaRepository.java
@@ -1,7 +1,6 @@
 package com.cotato.kampus.domain.post.dao.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -14,8 +13,6 @@ import com.cotato.kampus.domain.post.dao.entity.PostEntity;
 import com.cotato.kampus.domain.post.enums.PostStatus;
 
 public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
-
-	Long countByBoardId(Long boardId);
 
 	Slice<PostEntity> findAllByBoardIdAndPostStatus(Long boardId, PostStatus postStatus, Pageable pageable);
 

--- a/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/post/dao/repository/PostRepositoryImpl.java
@@ -58,11 +58,6 @@ public class PostRepositoryImpl implements PostRepository {
 	}
 
 	@Override
-	public Long countByBoardId(Long boardId) {
-		return postJpaRepository.countByBoardId(boardId);
-	}
-
-	@Override
 	public Slice<Post> findAllByBoardIdAndIdInAndPostStatus(Long boardId, List<Long> postIds, PostStatus postStatus, Pageable pageable) {
 		return postJpaRepository.findAllByBoardIdAndIdInAndPostStatus(boardId, postIds, postStatus, pageable)
 			.map(PostEntity::toDomain);

--- a/src/main/java/com/cotato/kampus/domain/post/implement/port/PostRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/port/PostRepository.java
@@ -23,9 +23,6 @@ public interface PostRepository {
 
 	void delete(Post post);
 
-	// 게시판의 총 게시글 수
-	Long countByBoardId(Long boardId);
-
 	// 게시판에서 일부(postIds) 게시글 조회
 	Slice<Post> findAllByBoardIdAndIdInAndPostStatus(Long boardId, List<Long> postIds, PostStatus postStatus, Pageable pageable);
 

--- a/src/main/java/com/cotato/kampus/domain/post/implement/post/PostFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/post/implement/post/PostFinder.java
@@ -2,7 +2,6 @@ package com.cotato.kampus.domain.post.implement.post;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -76,12 +75,6 @@ public class PostFinder {
 			.getContent();
 	}
 
-	public PostReferenceDto findPostReference(Long postId) {
-		return postRepository.findById(postId)
-			.map(PostReferenceDto::from)
-			.orElse(PostReferenceDto.deleted());
-	}
-
 	public Slice<Post> findAllByUserId(Long userId, int page) {
 		CustomPageRequest customPageRequest = new CustomPageRequest(page, PAGE_SIZE, Sort.Direction.DESC);
 		return postRepository.findAllByUserIdAndPostStatus(userId, PostStatus.PUBLISHED, customPageRequest.of(SORT_PROPERTY));
@@ -103,7 +96,4 @@ public class PostFinder {
 		return postRepository.findPostsByUserComments(userId, customPageRequest.of(SORT_PROPERTY));
 	}
 
-	public Long countByBoardId(Long boardId) {
-		return postRepository.countByBoardId(boardId);
-	}
 }


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
게시판 목록 조회 시 발생하는 N+1 쿼리 문제를 해결하여 성능 개선

### 상세 내용(Describe your changes)
**문제**
  - AdminService에서 게시판 목록과 각 게시판의 게시글 개수를 조회할 때 N+1 문제 발생
  - 378개 게시판 기준 379개의 쿼리가 실행되어 성능 저하

**해결 방법**
단일 쿼리로 게시판과 게시글 개수 동시 조회하도록 개선
  - COUNT 집계 함수로 각 게시판의 게시글 개수 계산
  - 불필요한 중복 조회 및 객체 변환 과정 제거

**성능 개선 결과**
  - 쿼리 개수: 379개 → 1개

### Issue Number or Link
Resolve #351 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Admin board listing now returns boards with precomputed post counts and excludes Card News from admin views for consistency.
- Bug Fixes
  - Admin post counts are accurate (including zero-post boards) and displayed without extra lookups.
- Chores
  - Removed older post-count and post-reference lookup paths to simplify data retrieval and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->