### PR TITLE
[REFACTOR] 댓글 조회 API 성능 최적화 및 isAuthor 필드 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
@@ -1,5 +1,7 @@
 package com.cotato.kampus.domain.comment.application;
 
+import static java.util.stream.Collectors.*;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -24,42 +26,93 @@ public class CommentMapper {
 
 	private final AnonymousNumberAllocator anonymousNumberAllocator;
 	private final CommentLikeRepository commentLikeRepository;
-	private final CommentFinder commentFinder;
 
 	public List<CommentDetail> buildCommentHierarchy(List<CommentDto> allCommentDtos, Long userId){
+		if (allCommentDtos.isEmpty()) {
+			return new ArrayList<>();
+		}
+
+		// 1. 필요한 데이터 준비
+		Map<Long, CommentDto> commentDtoMap = allCommentDtos.stream()
+			.collect(toMap(CommentDto::commentId, dto -> dto));
+		Map<Long, Boolean> likedCommentsMap = getLikedCommentsMap(userId, 
+			allCommentDtos.stream().map(CommentDto::commentId).toList());
+
+		// 2. 댓글을 CommentDetail로 변환
+		Map<Long, CommentDetail> commentMap = convertToCommentDetails(allCommentDtos, commentDtoMap, likedCommentsMap, userId);
+
+		// 3. 부모-자식 관계 형성 및 정렬
+		buildParentChildRelationships(commentMap);
+
+		// 4. 최상위 댓글 필터링 및 반환
+		return filterAndSortRootComments(commentMap);
+	}
+
+	/**
+	 * CommentDto를 CommentDetail로 변환하여 Map에 저장
+	 */
+	private Map<Long, CommentDetail> convertToCommentDetails(List<CommentDto> allCommentDtos, 
+			Map<Long, CommentDto> commentDtoMap, Map<Long, Boolean> likedCommentsMap, Long userId) {
 		Map<Long, CommentDetail> commentMap = new HashMap<>();
-
-		// 모든 댓글을 CommentDetail 객체로 변환하여 Map에 저장
+		
 		for (CommentDto dto : allCommentDtos) {
-			String targetAuthor = (dto.targetId() != null) ?
-				anonymousNumberAllocator.resolveAuthorName(commentFinder.findCommentDto(dto.targetId())) : null;
-
+			String targetAuthor = resolveTargetAuthor(dto, commentDtoMap);
+			
 			CommentDetail detail = CommentDetail.of(
 				dto,
 				anonymousNumberAllocator.resolveAuthorName(dto),
 				targetAuthor,
 				new ArrayList<>(),
-				commentLikeRepository.existsByUserIdAndCommentId(userId, dto.commentId()),
+				likedCommentsMap.getOrDefault(dto.commentId(), false),
 				userId.equals(dto.userId())
 			);
 			commentMap.put(dto.commentId(), detail);
 		}
+		return commentMap;
+	}
+	
+	/**
+	 * targetId에 해당하는 작성자 이름 확인
+	 */
+	private String resolveTargetAuthor(CommentDto dto, Map<Long, CommentDto> commentDtoMap) {
+		if (dto.targetId() == null) {
+			return null;
+		}
+		
+		CommentDto targetComment = commentDtoMap.get(dto.targetId());
+		if (isValidTargetRelation(dto, targetComment)) {
+			return anonymousNumberAllocator.resolveAuthorName(targetComment);
+		}
+		return null;
+	}
 
+	/**
+	 * 부모-자식 관계 형성 및 대댓글 정렬
+	 */
+	private void buildParentChildRelationships(Map<Long, CommentDetail> commentMap) {
 		// 부모-자식 관계 형성
 		for (CommentDetail detail : commentMap.values()) {
 			if(detail.parentId() != null) {
 				CommentDetail parent = commentMap.get(detail.parentId());
-				if(parent != null) {
+				if(isValidParentChildRelation(detail, parent)) {
 					parent.replies().add(detail);
-					parent.replies().sort(Comparator.comparing(CommentDetail::createdTime));
 				}
 			}
 		}
+		
+		// 대댓글 정렬 (replies가 있는 댓글만 대상)
+		commentMap.values().stream()
+			.filter(detail -> !detail.replies().isEmpty())
+			.forEach(detail -> detail.replies().sort(Comparator.comparing(CommentDetail::createdTime)));
+	}
 
-		// 최종 필터링 및 내용 변경
+	/**
+	 * 최상위 댓글 필터링 및 정렬하여 반환
+	 */
+	private List<CommentDetail> filterAndSortRootComments(Map<Long, CommentDetail> commentMap) {
 		List<CommentDetail> rootComments = new ArrayList<>();
+		
 		for(CommentDetail detail : commentMap.values()) {
-			// 최상위 댓글 대상으로 필터링 시작
 			if(detail.parentId() == null) {
 				boolean isDeleted = detail.commentStatus() != CommentStatus.NORMAL;
 				boolean hasReplies = !detail.replies().isEmpty();
@@ -73,10 +126,54 @@ public class CommentMapper {
 				// 삭제됐고 대댓글도 없는 경우는 아무것도 하지 않음 (결과에서 제외)
 			}
 		}
-
+		
 		rootComments.sort(Comparator.comparing(CommentDetail::createdTime));
-
 		return rootComments;
+	}
+
+	/**
+	 * 좋아요 정보를 배치로 조회하여 N+1 문제 해결
+	 */
+	private Map<Long, Boolean> getLikedCommentsMap(Long userId, List<Long> commentIds) {
+		if (commentIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		
+		// 좋아요한 댓글 ID들을 배치로 조회
+		List<Long> likedCommentIds = commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(userId, commentIds);
+		
+		// 결과를 Map으로 변환
+		Map<Long, Boolean> result = new HashMap<>();
+		for (Long commentId : commentIds) {
+			result.put(commentId, likedCommentIds.contains(commentId));
+		}
+		return result;
+	}
+
+	/**
+	 * targetId와 parentId 관계가 유효한지 검증
+	 * - targetId가 있으면 같은 parentId를 가져야 함 (동일한 댓글 스레드 내에서만 답글 가능)
+	 * - 또는 targetId가 parentId와 같아야 함 (최상위 댓글에 대한 직접 답글)
+	 */
+	private boolean isValidTargetRelation(CommentDto current, CommentDto target) {
+		if (current.parentId() == null) {
+			return false; // 최상위 댓글은 targetId를 가질 수 없음
+		}
+		
+		// targetId가 parentId와 같거나 (최상위 댓글에 대한 답글)
+		// target도 같은 parentId를 가져야 함 (동일 스레드 내 답글)
+		return current.targetId().equals(current.parentId()) || 
+			   (target.parentId() != null && target.parentId().equals(current.parentId()));
+	}
+
+	/**
+	 * 부모-자식 관계가 유효한지 검증
+	 * - 순환 참조 방지
+	 * - 자기 자신을 부모로 설정하는 것 방지
+	 */
+	private boolean isValidParentChildRelation(CommentDetail child, CommentDetail parent) {
+		// 자기 자신을 부모로 설정 불가 또는 대댓글은 최상위 댓글만 부모로 가질 수 있음
+		return !child.commentId().equals(parent.commentId()) && parent.parentId() == null;
 	}
 
 }

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
@@ -39,7 +39,8 @@ public class CommentMapper {
 				anonymousNumberAllocator.resolveAuthorName(dto),
 				targetAuthor,
 				new ArrayList<>(),
-				commentLikeRepository.existsByUserIdAndCommentId(userId, dto.commentId())
+				commentLikeRepository.existsByUserIdAndCommentId(userId, dto.commentId()),
+				userId.equals(dto.userId())
 			);
 			commentMap.put(dto.commentId(), detail);
 		}

--- a/src/main/java/com/cotato/kampus/domain/comment/dao/CommentLikeRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dao/CommentLikeRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.cotato.kampus.domain.comment.domain.CommentLike;
 
@@ -15,4 +17,11 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
 	Optional<CommentLike> findByUserIdAndCommentId(Long userId, Long commentId);
 
 	List<CommentLike> findAllByCommentId(Long commentId);
+
+	/**
+	 * 특정 사용자가 좋아요한 댓글 ID 목록을 배치로 조회
+	 * N+1 문제 해결을 위한 배치 조회 메서드
+	 */
+	@Query("SELECT cl.commentId FROM CommentLike cl WHERE cl.userId = :userId AND cl.commentId IN :commentIds")
+	List<Long> findCommentIdsByUserIdAndCommentIdIn(@Param("userId") Long userId, @Param("commentIds") List<Long> commentIds);
 }

--- a/src/main/java/com/cotato/kampus/domain/comment/dao/CommentLikeRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dao/CommentLikeRepository.java
@@ -18,10 +18,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
 
 	List<CommentLike> findAllByCommentId(Long commentId);
 
-	/**
-	 * 특정 사용자가 좋아요한 댓글 ID 목록을 배치로 조회
-	 * N+1 문제 해결을 위한 배치 조회 메서드
-	 */
 	@Query("SELECT cl.commentId FROM CommentLike cl WHERE cl.userId = :userId AND cl.commentId IN :commentIds")
 	List<Long> findCommentIdsByUserIdAndCommentIdIn(@Param("userId") Long userId, @Param("commentIds") List<Long> commentIds);
 }

--- a/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
@@ -31,6 +31,9 @@ public record CommentDetail(
 	@Schema(example = "true")
 	boolean isLiked,
 
+	@Schema(example = "true")
+	boolean isAuthor,
+
 	@Schema(example = "2025-01-17T21:03:30.218321")
 	LocalDateTime createdTime,
 
@@ -38,7 +41,7 @@ public record CommentDetail(
 	@Schema(description = "댓글의 대댓글 리스트")
 	List<CommentDetail> replies
 ) {
-	public static CommentDetail of(CommentDto commentDto, String author, String targetAuthor, List<CommentDetail> replies, boolean isLiked) {
+	public static CommentDetail of(CommentDto commentDto, String author, String targetAuthor, List<CommentDetail> replies, boolean isLiked, boolean isAuthor) {
 		return new CommentDetail(
 			commentDto.commentId(),
 			commentDto.parentId(),
@@ -48,6 +51,7 @@ public record CommentDetail(
 			commentDto.content(),
 			commentDto.likes(),
 			isLiked,
+			isAuthor,
 			commentDto.createdTime(),
 			replies
 		);
@@ -63,6 +67,7 @@ public record CommentDetail(
 			"This comment was deleted.",
 			this.likes,
 			this.isLiked,
+			this.isAuthor,
 			this.createdTime,
 			this.replies
 		);

--- a/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
@@ -41,6 +41,8 @@ public record CommentDetail(
 	@Schema(description = "댓글의 대댓글 리스트")
 	List<CommentDetail> replies
 ) {
+	public static final String DELETED_PLACEHOLDER = "This comment was deleted.";
+
 	public static CommentDetail of(CommentDto commentDto, String author, String targetAuthor, List<CommentDetail> replies, boolean isLiked, boolean isAuthor) {
 		return new CommentDetail(
 			commentDto.commentId(),
@@ -64,7 +66,7 @@ public record CommentDetail(
 			this.targetAuthor,
 			this.commentStatus,
 			this.author,
-			"This comment was deleted.",
+			DELETED_PLACEHOLDER,
 			this.likes,
 			this.isLiked,
 			this.isAuthor,

--- a/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dto/CommentDetail.java
@@ -31,7 +31,10 @@ public record CommentDetail(
 	@Schema(example = "true")
 	boolean isLiked,
 
-	@Schema(example = "true")
+	@Schema(
+		example = "true",
+		description = "현재 로그인한 사용자가 해당 댓글의 작성자인지 여부"
+	)
 	boolean isAuthor,
 
 	@Schema(example = "2025-01-17T21:03:30.218321")

--- a/src/test/java/com/cotato/kampus/domain/comment/application/CommentMapperTest.java
+++ b/src/test/java/com/cotato/kampus/domain/comment/application/CommentMapperTest.java
@@ -1,0 +1,484 @@
+package com.cotato.kampus.domain.comment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.kampus.domain.comment.dao.CommentLikeRepository;
+import com.cotato.kampus.domain.comment.dto.CommentDetail;
+import com.cotato.kampus.domain.comment.dto.CommentDto;
+import com.cotato.kampus.domain.comment.enums.CommentStatus;
+import com.cotato.kampus.domain.comment.enums.ReportStatus;
+import com.cotato.kampus.domain.common.enums.Anonymity;
+
+@ExtendWith(MockitoExtension.class)
+class CommentMapperTest {
+
+	@InjectMocks
+	private CommentMapper commentMapper;
+
+	@Mock
+	private AnonymousNumberAllocator anonymousNumberAllocator;
+
+	@Mock
+	private CommentLikeRepository commentLikeRepository;
+
+
+	@Test
+	@DisplayName("현재 유저가 작성한 댓글의 isAuthor는 true여야 한다")
+	void buildCommentHierarchy_userIsAuthor_shouldReturnTrue() {
+		// given
+		Long currentUserId = 1L;
+		Long commentId = 10L;
+		
+		CommentDto commentDto = new CommentDto(
+			commentId,
+			currentUserId, // 현재 유저가 작성한 댓글
+			1L,
+			"Test content",
+			0L,
+			ReportStatus.NORMAL,
+			CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS,
+			0L,
+			1,
+			null,
+			null,
+			LocalDateTime.now()
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(commentDto)).willReturn("Anonymous1");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(commentId)))
+			.willReturn(Arrays.asList()); // 좋아요하지 않음
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Arrays.asList(commentDto), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1);
+		CommentDetail commentDetail = result.get(0);
+		assertThat(commentDetail.isAuthor()).isTrue();
+		assertThat(commentDetail.commentId()).isEqualTo(commentId);
+	}
+
+	@Test
+	@DisplayName("현재 유저가 작성하지 않은 댓글의 isAuthor는 false여야 한다")
+	void buildCommentHierarchy_userIsNotAuthor_shouldReturnFalse() {
+		// given
+		Long currentUserId = 1L;
+		Long otherUserId = 2L;
+		Long commentId = 10L;
+		
+		CommentDto commentDto = new CommentDto(
+			commentId,
+			otherUserId, // 다른 유저가 작성한 댓글
+			1L,
+			"Test content",
+			0L,
+			ReportStatus.NORMAL,
+			CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS,
+			0L,
+			1,
+			null,
+			null,
+			LocalDateTime.now()
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(commentDto)).willReturn("Anonymous1");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(commentId)))
+			.willReturn(Arrays.asList()); // 좋아요하지 않음
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Arrays.asList(commentDto), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1);
+		CommentDetail commentDetail = result.get(0);
+		assertThat(commentDetail.isAuthor()).isFalse();
+		assertThat(commentDetail.commentId()).isEqualTo(commentId);
+	}
+
+	@Test
+	@DisplayName("대댓글도 isAuthor 필드가 올바르게 설정되어야 한다")
+	void buildCommentHierarchy_withReplies_shouldSetIsAuthorCorrectly() {
+		// given
+		Long currentUserId = 1L;
+		Long otherUserId = 2L;
+		
+		// 부모 댓글 (다른 유저 작성)
+		CommentDto parentComment = new CommentDto(
+			10L,
+			otherUserId,
+			1L,
+			"Parent comment",
+			0L,
+			ReportStatus.NORMAL,
+			CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS,
+			0L,
+			1,
+			null,
+			null,
+			LocalDateTime.now()
+		);
+
+		// 대댓글 (현재 유저 작성)
+		CommentDto replyComment = new CommentDto(
+			11L,
+			currentUserId,
+			1L,
+			"Reply comment",
+			0L,
+			ReportStatus.NORMAL,
+			CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS,
+			0L,
+			2,
+			10L, // 부모 댓글 ID
+			null,
+			LocalDateTime.now().plusMinutes(1)
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(parentComment)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(replyComment)).willReturn("Anonymous2");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
+			.willReturn(Arrays.asList()); // 좋아요하지 않음
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(parentComment, replyComment), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1);
+		
+		CommentDetail parentDetail = result.get(0);
+		assertThat(parentDetail.isAuthor()).isFalse(); // 다른 유저가 작성
+		assertThat(parentDetail.replies()).hasSize(1);
+		
+		CommentDetail replyDetail = parentDetail.replies().get(0);
+		assertThat(replyDetail.isAuthor()).isTrue(); // 현재 유저가 작성
+	}
+
+	// ========== 댓글 상태 처리 테스트 ==========
+
+	@Test
+	@DisplayName("삭제된 댓글이지만 대댓글이 있으면 내용을 마스킹하여 포함해야 한다")
+	void buildCommentHierarchy_deletedCommentWithReplies_shouldMaskContent() {
+		// given
+		Long currentUserId = 1L;
+		
+		// 삭제된 부모 댓글
+		CommentDto deletedParent = new CommentDto(
+			10L, 2L, 1L, "Original content", 0L,
+			ReportStatus.NORMAL, CommentStatus.DELETED_BY_USER, // 삭제됨
+			Anonymity.ANONYMOUS, 0L, 1, null, null,
+			LocalDateTime.now()
+		);
+		
+		// 대댓글
+		CommentDto reply = new CommentDto(
+			11L, currentUserId, 1L, "Reply to deleted", 0L,
+			ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 2, 10L, null,
+			LocalDateTime.now().plusMinutes(1)
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(deletedParent)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(reply)).willReturn("Anonymous2");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(deletedParent, reply), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1);
+		CommentDetail parentDetail = result.get(0);
+		assertThat(parentDetail.content()).isEqualTo("This comment was deleted."); // 마스킹됨
+		assertThat(parentDetail.replies()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("삭제된 댓글이고 대댓글도 없으면 결과에서 완전히 제외해야 한다")
+	void buildCommentHierarchy_deletedCommentWithoutReplies_shouldExclude() {
+		// given
+		Long currentUserId = 1L;
+		
+		// 삭제된 댓글 (대댓글 없음)
+		CommentDto deletedComment = new CommentDto(
+			10L, 2L, 1L, "To be deleted", 0L,
+			ReportStatus.NORMAL, CommentStatus.DELETED_BY_USER, // 삭제됨
+			Anonymity.ANONYMOUS, 0L, 1, null, null,
+			LocalDateTime.now()
+		);
+		
+		// 정상 댓글
+		CommentDto normalComment = new CommentDto(
+			11L, currentUserId, 1L, "Normal comment", 0L,
+			ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 2, null, null,
+			LocalDateTime.now().plusMinutes(1)
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(deletedComment)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(normalComment)).willReturn("Anonymous2");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(deletedComment, normalComment), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1); // 삭제된 댓글은 제외됨
+		assertThat(result.get(0).commentId()).isEqualTo(11L); // 정상 댓글만 포함
+	}
+
+	// ========== 좋아요 기능 테스트 ==========
+
+	@Test
+	@DisplayName("좋아요한 댓글의 isLiked는 true여야 한다")
+	void buildCommentHierarchy_likedComment_shouldReturnTrue() {
+		// given
+		Long currentUserId = 1L;
+		Long commentId = 10L;
+		
+		CommentDto commentDto = new CommentDto(
+			commentId, 2L, 1L, "Liked comment", 5L,
+			ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null,
+			LocalDateTime.now()
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(commentDto)).willReturn("Anonymous1");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(commentId)))
+			.willReturn(Arrays.asList(commentId)); // 좋아요함
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Arrays.asList(commentDto), currentUserId);
+
+		// then
+		assertThat(result.get(0).isLiked()).isTrue();
+		assertThat(result.get(0).likes()).isEqualTo(5L);
+	}
+
+	@Test
+	@DisplayName("좋아요하지 않은 댓글의 isLiked는 false여야 한다")
+	void buildCommentHierarchy_notLikedComment_shouldReturnFalse() {
+		// given
+		Long currentUserId = 1L;
+		Long commentId = 10L;
+		
+		CommentDto commentDto = new CommentDto(
+			commentId, 2L, 1L, "Not liked comment", 3L,
+			ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null,
+			LocalDateTime.now()
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(commentDto)).willReturn("Anonymous1");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(commentId)))
+			.willReturn(Collections.emptyList()); // 좋아요하지 않음
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Arrays.asList(commentDto), currentUserId);
+
+		// then
+		assertThat(result.get(0).isLiked()).isFalse();
+		assertThat(result.get(0).likes()).isEqualTo(3L);
+	}
+
+	// ========== 정렬 기능 테스트 ==========
+
+	@Test
+	@DisplayName("최상위 댓글들이 시간순으로 정렬되어야 한다")
+	void buildCommentHierarchy_rootComments_shouldBeSortedByTime() {
+		// given
+		Long currentUserId = 1L;
+		LocalDateTime baseTime = LocalDateTime.now();
+		
+		// 시간 순서대로 생성하지 않음 (의도적으로)
+		CommentDto comment3 = new CommentDto(
+			30L, 2L, 1L, "Third comment", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null, baseTime.plusMinutes(3)
+		);
+		
+		CommentDto comment1 = new CommentDto(
+			10L, 2L, 1L, "First comment", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null, baseTime.plusMinutes(1)
+		);
+		
+		CommentDto comment2 = new CommentDto(
+			20L, 2L, 1L, "Second comment", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null, baseTime.plusMinutes(2)
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(comment1)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(comment2)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(comment3)).willReturn("Anonymous1");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(30L, 10L, 20L)))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(comment3, comment1, comment2), currentUserId);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).commentId()).isEqualTo(10L); // 첫 번째
+		assertThat(result.get(1).commentId()).isEqualTo(20L); // 두 번째
+		assertThat(result.get(2).commentId()).isEqualTo(30L); // 세 번째
+	}
+
+	@Test
+	@DisplayName("대댓글들이 시간순으로 정렬되어야 한다")
+	void buildCommentHierarchy_replies_shouldBeSortedByTime() {
+		// given
+		Long currentUserId = 1L;
+		LocalDateTime baseTime = LocalDateTime.now();
+		
+		CommentDto parent = new CommentDto(
+			10L, 2L, 1L, "Parent comment", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null, baseTime
+		);
+		
+		// 대댓글들 (시간 순서 섞임)
+		CommentDto reply3 = new CommentDto(
+			13L, currentUserId, 1L, "Third reply", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 2, 10L, null, baseTime.plusMinutes(3)
+		);
+		
+		CommentDto reply1 = new CommentDto(
+			11L, currentUserId, 1L, "First reply", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 2, 10L, null, baseTime.plusMinutes(1)
+		);
+		
+		CommentDto reply2 = new CommentDto(
+			12L, currentUserId, 1L, "Second reply", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 2, 10L, null, baseTime.plusMinutes(2)
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(parent)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(reply1)).willReturn("Anonymous2");
+		given(anonymousNumberAllocator.resolveAuthorName(reply2)).willReturn("Anonymous2");
+		given(anonymousNumberAllocator.resolveAuthorName(reply3)).willReturn("Anonymous2");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 13L, 11L, 12L)))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(parent, reply3, reply1, reply2), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1);
+		CommentDetail parentDetail = result.get(0);
+		assertThat(parentDetail.replies()).hasSize(3);
+		
+		// 대댓글들이 시간순으로 정렬되었는지 확인
+		assertThat(parentDetail.replies().get(0).commentId()).isEqualTo(11L); // 첫 번째
+		assertThat(parentDetail.replies().get(1).commentId()).isEqualTo(12L); // 두 번째
+		assertThat(parentDetail.replies().get(2).commentId()).isEqualTo(13L); // 세 번째
+	}
+
+	// ========== targetId/parentId 관계 검증 테스트 ==========
+
+	@Test
+	@DisplayName("유효한 targetId 관계면 targetAuthor가 설정되어야 한다")
+	void buildCommentHierarchy_validTargetRelation_shouldSetTargetAuthor() {
+		// given
+		Long currentUserId = 1L;
+		
+		CommentDto parent = new CommentDto(
+			10L, 2L, 1L, "Parent comment", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null, LocalDateTime.now()
+		);
+		
+		// targetId가 parentId와 같은 경우 (유효)
+		CommentDto reply = new CommentDto(
+			11L, currentUserId, 1L, "Reply to parent", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 2, 10L, 10L, // parentId = targetId = 10L
+			LocalDateTime.now().plusMinutes(1)
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(parent)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(reply)).willReturn("Anonymous2");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(parent, reply), currentUserId);
+
+		// then
+		CommentDetail replyDetail = result.get(0).replies().get(0);
+		assertThat(replyDetail.targetAuthor()).isEqualTo("Anonymous1"); // targetAuthor 설정됨
+	}
+
+	// ========== Edge Case 테스트 ==========
+
+	@Test
+	@DisplayName("빈 리스트를 입력하면 빈 결과를 반환해야 한다")
+	void buildCommentHierarchy_emptyInput_shouldReturnEmpty() {
+		// given
+		Long currentUserId = 1L;
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Collections.emptyList(), currentUserId);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("대댓글의 대댓글은 허용되지 않아야 한다")
+	void buildCommentHierarchy_nestedReplies_shouldBeRejected() {
+		// given
+		Long currentUserId = 1L;
+		
+		CommentDto parent = new CommentDto(
+			10L, 2L, 1L, "Parent", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 1, null, null, LocalDateTime.now()
+		);
+		
+		CommentDto reply = new CommentDto(
+			11L, 3L, 1L, "Reply", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 2, 10L, null, LocalDateTime.now().plusMinutes(1)
+		);
+		
+		// 대댓글의 대댓글 시도 (거부되어야 함)
+		CommentDto nestedReply = new CommentDto(
+			12L, currentUserId, 1L, "Nested reply", 0L, ReportStatus.NORMAL, CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS, 0L, 3, 11L, null, // reply를 부모로 설정
+			LocalDateTime.now().plusMinutes(2)
+		);
+
+		given(anonymousNumberAllocator.resolveAuthorName(parent)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(reply)).willReturn("Anonymous2");
+		given(anonymousNumberAllocator.resolveAuthorName(nestedReply)).willReturn("Anonymous3");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L, 12L)))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(parent, reply, nestedReply), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1);
+		CommentDetail parentDetail = result.get(0);
+		assertThat(parentDetail.replies()).hasSize(1); // reply만 포함
+		assertThat(parentDetail.replies().get(0).replies()).isEmpty(); // nested reply는 거부됨
+	}
+}

--- a/src/test/java/com/cotato/kampus/domain/comment/application/CommentMapperTest.java
+++ b/src/test/java/com/cotato/kampus/domain/comment/application/CommentMapperTest.java
@@ -1,6 +1,8 @@
 package com.cotato.kampus.domain.comment.application;
 
+import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDateTime;
@@ -59,8 +61,8 @@ class CommentMapperTest {
 		);
 
 		given(anonymousNumberAllocator.resolveAuthorName(commentDto)).willReturn("Anonymous1");
-		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(commentId)))
-			.willReturn(Arrays.asList()); // 좋아요하지 않음
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, anyList()))
+			.willReturn(emptyList()); // 좋아요하지 않음
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Arrays.asList(commentDto), currentUserId);
@@ -97,8 +99,8 @@ class CommentMapperTest {
 		);
 
 		given(anonymousNumberAllocator.resolveAuthorName(commentDto)).willReturn("Anonymous1");
-		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(commentId)))
-			.willReturn(Arrays.asList()); // 좋아요하지 않음
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, anyList()))
+			.willReturn(emptyList()); // 좋아요하지 않음
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Arrays.asList(commentDto), currentUserId);
@@ -153,8 +155,8 @@ class CommentMapperTest {
 
 		given(anonymousNumberAllocator.resolveAuthorName(parentComment)).willReturn("Anonymous1");
 		given(anonymousNumberAllocator.resolveAuthorName(replyComment)).willReturn("Anonymous2");
-		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
-			.willReturn(Arrays.asList()); // 좋아요하지 않음
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, anyList()))
+			.willReturn(emptyList()); // 좋아요하지 않음
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
@@ -198,7 +200,7 @@ class CommentMapperTest {
 		given(anonymousNumberAllocator.resolveAuthorName(deletedParent)).willReturn("Anonymous1");
 		given(anonymousNumberAllocator.resolveAuthorName(reply)).willReturn("Anonymous2");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
-			.willReturn(Collections.emptyList());
+			.willReturn(emptyList());
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
@@ -236,7 +238,7 @@ class CommentMapperTest {
 		given(anonymousNumberAllocator.resolveAuthorName(deletedComment)).willReturn("Anonymous1");
 		given(anonymousNumberAllocator.resolveAuthorName(normalComment)).willReturn("Anonymous2");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
-			.willReturn(Collections.emptyList());
+			.willReturn(emptyList());
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
@@ -291,7 +293,7 @@ class CommentMapperTest {
 
 		given(anonymousNumberAllocator.resolveAuthorName(commentDto)).willReturn("Anonymous1");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(commentId)))
-			.willReturn(Collections.emptyList()); // 좋아요하지 않음
+			.willReturn(emptyList()); // 좋아요하지 않음
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Arrays.asList(commentDto), currentUserId);
@@ -330,7 +332,7 @@ class CommentMapperTest {
 		given(anonymousNumberAllocator.resolveAuthorName(comment2)).willReturn("Anonymous1");
 		given(anonymousNumberAllocator.resolveAuthorName(comment3)).willReturn("Anonymous1");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(30L, 10L, 20L)))
-			.willReturn(Collections.emptyList());
+			.willReturn(emptyList());
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
@@ -376,7 +378,7 @@ class CommentMapperTest {
 		given(anonymousNumberAllocator.resolveAuthorName(reply2)).willReturn("Anonymous2");
 		given(anonymousNumberAllocator.resolveAuthorName(reply3)).willReturn("Anonymous2");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 13L, 11L, 12L)))
-			.willReturn(Collections.emptyList());
+			.willReturn(emptyList());
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
@@ -416,7 +418,7 @@ class CommentMapperTest {
 		given(anonymousNumberAllocator.resolveAuthorName(parent)).willReturn("Anonymous1");
 		given(anonymousNumberAllocator.resolveAuthorName(reply)).willReturn("Anonymous2");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L)))
-			.willReturn(Collections.emptyList());
+			.willReturn(emptyList());
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
@@ -436,7 +438,7 @@ class CommentMapperTest {
 		Long currentUserId = 1L;
 
 		// when
-		List<CommentDetail> result = commentMapper.buildCommentHierarchy(Collections.emptyList(), currentUserId);
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(emptyList(), currentUserId);
 
 		// then
 		assertThat(result).isEmpty();
@@ -469,7 +471,7 @@ class CommentMapperTest {
 		given(anonymousNumberAllocator.resolveAuthorName(reply)).willReturn("Anonymous2");
 		given(anonymousNumberAllocator.resolveAuthorName(nestedReply)).willReturn("Anonymous3");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(currentUserId, Arrays.asList(10L, 11L, 12L)))
-			.willReturn(Collections.emptyList());
+			.willReturn(emptyList());
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
댓글 조회 API에 isAuthor 필드 추가 및 DB 접근 최적화로 성능 개선

### 상세 내용(Describe your changes)
1. CommentDetail 레코드에 boolean isAuthor 필드 추가
- 현재 로그인한 사용자가 댓글 작성자인지 확인 가능
- 프론트엔드 댓글 삭제 기능 지원

2. DB 접근 패턴 최적화
- 좋아요 조회: 개별 쿼리 -> IN 절 배치 조회로 변경
- targetAuthor 조회:  CommentFinder 의존성 → 메모리 Map 활용으로 변경
- 전체 쿼리 수 감소: 11개 댓글 기준 13개 → 3개 쿼리

3. 코드 구조 개선
- CommentMapper를 기능별 메서드로 분리하여 가독성 향상
- 부모-자식 관계 및 targetId 유효성 검증 로직 추가
- 데이터 변환 과정을 단계별로 명확히 분리

4. 테스트 코드 작성


### Issue Number or Link
Resolve #357 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows an “author” indicator on comments/replies you wrote.
  * Displays target author names for valid reply relationships.

* **Bug Fixes**
  * Deleted comments without replies are hidden; with replies, content is masked as "This comment was deleted."
  * Only one-level replies are shown; deeper nesting is excluded.
  * Ensures chronological ordering for comments and replies.
  * Fixes like-status and counts accuracy.

* **Performance**
  * Faster like-state loading via batched retrieval.

* **Tests**
  * Added comprehensive tests for author flags, deletions, likes, sorting, and reply handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->