### PR TITLE
[FIX] 채팅방 생성 시 잘못된 referenceId 전달 버그 수정

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceImpl.java
@@ -65,15 +65,16 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		Long senderId = apiUserResolver.getCurrentUserId();
 
 		// 3. 채팅방 중복 검증(이미 있는 채팅방)
-		chatRoomValidator.validateDuplicateChatRoom(chatReference.getReferenceId(), senderId, chatType);
+		chatRoomValidator.validateDuplicateChatRoom(referenceId, senderId, chatType);
 
 		// 4. 채팅방 생성(생성 시 검증 이루어짐(sender != receiver))
-		Long chatroomId = chatRoomAppender.appendChatRoom(chatReference.getReferenceId(), chatType, senderId,
-			chatReference.getReferenceUserId());
+		Long receiverId = chatReference.getReferenceUserId();
+		Long chatroomId = chatRoomAppender.appendChatRoom(referenceId, chatType, senderId,
+			receiverId);
 
 		// 5. 채팅방 리스트 조회시 사용되는 뷰 생성
 		chatroomMetadataAppender.createMetadataPair(chatroomId, chatType, referenceId, chatReference.getTitle(),
-			senderId, chatReference.getReferenceUserId());
+			senderId, receiverId);
 
 		return chatroomId;
 	}

--- a/src/main/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceImpl.java
@@ -68,7 +68,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		chatRoomValidator.validateDuplicateChatRoom(chatReference.getReferenceId(), senderId, chatType);
 
 		// 4. 채팅방 생성(생성 시 검증 이루어짐(sender != receiver))
-		Long chatroomId = chatRoomAppender.appendChatRoom(chatReference.getReferenceUserId(), chatType, senderId,
+		Long chatroomId = chatRoomAppender.appendChatRoom(chatReference.getReferenceId(), chatType, senderId,
 			chatReference.getReferenceUserId());
 
 		// 5. 채팅방 리스트 조회시 사용되는 뷰 생성

--- a/src/test/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceTest.java
@@ -55,26 +55,41 @@ class ChatRoomServiceTest {
 	ChatroomMetadataMapper chatroomMetadataMapper;
 
 	@Test
-	@DisplayName("postId로 채팅방을 생성한다.")
+	@DisplayName("postId로 채팅방을 생성하고 올바른 파라미터가 전달되는지 검증한다.")
 	public void createChatRoom() {
-		//postId = 1, senderId = 1, receiverId = 2
+		// given
+		Long postId = 999L;
+		Long senderId = 777L;
+		Long receiverId = 555L;
+		Long expectedChatRoomId = 123L;
 
 		ChatReference chatReference = ChatReference.builder()
-			.referenceId(1L)
-			.referenceUserId(2L)
+			.referenceId(postId)
+			.referenceUserId(receiverId)
 			.title("test")
 			.build();
 
-		when(referenceFinder.find(1L, ChatType.POST)).thenReturn(chatReference);
-		when(apiUserResolver.getCurrentUserId()).thenReturn(1L);
-		doNothing().when(chatRoomValidator).validateDuplicateChatRoom(1L, 1L, ChatType.POST);
-		when(chatRoomAppender.appendChatRoom(2L, ChatType.POST, 1L, 2L)).thenReturn(123L);
+		when(referenceFinder.find(postId, ChatType.POST)).thenReturn(chatReference);
+		when(apiUserResolver.getCurrentUserId()).thenReturn(senderId);
+		doNothing().when(chatRoomValidator).validateDuplicateChatRoom(postId, senderId, ChatType.POST);
+		when(chatRoomAppender.appendChatRoom(postId, ChatType.POST, senderId, receiverId)).thenReturn(expectedChatRoomId);
 		doNothing().when(chatroomMetadataAppender)
-			.createMetadataPair(123L, ChatType.POST, chatReference.getReferenceId(),
-				chatReference.getTitle(), 1L, 2L);
+			.createMetadataPair(expectedChatRoomId, ChatType.POST, postId,
+				chatReference.getTitle(), senderId, receiverId);
 
-		Long id = target.createChatRoom(chatReference.getReferenceId(), ChatType.POST);
-		assertThat(id).isEqualTo(123L);
+		// when
+		Long id = target.createChatRoom(postId, ChatType.POST);
+		
+		// then
+		assertThat(id).isEqualTo(expectedChatRoomId);
+		
+		// 파라미터 순서 검증: 첫 번째는 postId여야 함 (receiverId가 아닌)
+		verify(chatRoomAppender).appendChatRoom(
+			eq(postId),      // referenceId = postId (NOT receiverId)
+			eq(ChatType.POST),
+			eq(senderId),
+			eq(receiverId)
+		);
 	}
 
 	@Test


### PR DESCRIPTION
- ChatRoomServiceImpl: appendChatRoom 호출 시 올바른 referenceId 전달
- ChatRoomServiceTest: 파라미터 순서 검증 테스트 개선으로 버그 재발 방지

---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
  - 채팅방 생성 시 잘못된 referenceId가 전달되는 버그 수정
  - 단위 테스트 개선으로 버그 재발 방지

### 상세 내용(Describe your changes)
 🐛 Bug Fix
  - ChatRoomServiceImpl.createChatRoom()에서 chatRoomAppender.appendChatRoom() 호출 시 첫 번째
  파라미터로 chatReference.getReferenceUserId() 대신 chatReference.getReferenceId()를 전달하도록  수정

  🧪 Test Enhancement
  - ChatRoomServiceTest.createChatRoom() 테스트 개선
  - 구분 가능한 변수 사용: postId=999L, senderId=777L, receiverId=555L
  - verify() 검증 추가로 appendChatRoom() 메서드에 올바른 파라미터 순서로 값이 전달되는지 확인


### Issue Number or Link
Resolve #362 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Corrected chat room creation to use the intended reference ID (e.g., post) and proper participant IDs, preventing misrouted chats and ensuring metadata and participants are assigned to the correct conversation.
- Tests
  - Updated unit tests to assert correct parameter order and ID usage during chat room creation, improving regression coverage and confidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->