### PR TITLE
[REFACTOR] ProductDetailResponse를 ProductDetails 레코드로 래핑하도록 변경

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/product/api/response/ProductDetailResponse.java
+++ b/src/main/java/com/cotato/kampus/domain/product/api/response/ProductDetailResponse.java
@@ -1,46 +1,11 @@
 package com.cotato.kampus.domain.product.api.response;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import com.cotato.kampus.domain.product.enums.ProductStatus;
 import com.cotato.kampus.domain.product.domain.ProductDetails;
-import com.cotato.kampus.domain.product.domain.ProductPhotoInfo;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record ProductDetailResponse(
-	Long productId,
-	Long sellerId,
-	String sellerName,
-	String title,
-	int price,
-	List<String> categories,
-	String description,
-	List<ProductPhotoInfo> photos,
-	ProductStatus productStatus,
-	int scrapCount,
-	int chatCount,
-	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-	LocalDateTime createdTime,
-	boolean isAuthor,
-	boolean isScrapped
+	ProductDetails productDetails
 ) {
 	public static ProductDetailResponse from(ProductDetails productDetails) {
-		return new ProductDetailResponse(
-			productDetails.productId(),
-			productDetails.sellerId(),
-			productDetails.sellerName(),
-			productDetails.title(),
-			productDetails.price(),
-			productDetails.categories(),
-			productDetails.description(),
-			productDetails.photos(),
-			productDetails.postStatus(),
-			productDetails.scrapCount(),
-			productDetails.chatCount(),
-			productDetails.createdTime(),
-			productDetails.isAuthor(),
-			productDetails.isScrapped()
-		);
+		return new ProductDetailResponse(productDetails);
 	}
 }


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
ProductDetailResponse를 ProductDetails 레코드로 래핑하도록 리팩토링

### 상세 내용(Describe your changes)
 - ProductDetailResponse가 개별 필드들을 직접 노출하는 대신 ProductDetails 레코드를 감싸도록 수정
 
### Issue Number or Link
Resolve #364 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the product detail API response into a single, nested object for clearer structure and easier evolution.
  * Reduced redundancy by consolidating multiple fields into a cohesive payload.
  * No changes to visible app behavior; existing product detail views continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->