### PR TITLE
[FIX] ProductDetails의 postStatus를 productStatus로 변경

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/product/domain/ProductDetails.java
+++ b/src/main/java/com/cotato/kampus/domain/product/domain/ProductDetails.java
@@ -18,7 +18,7 @@ public record ProductDetails(
 	int scrapCount,
 	int chatCount,
 	int bumpCount,
-	ProductStatus postStatus,
+	ProductStatus productStatus,
 	LocalDateTime bumpedTime,
 	LocalDateTime createdTime,
 	boolean isAuthor,


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
ProductDetails의 postStatus를 productStatus로 변경

### 상세 내용(Describe your changes)


### Issue Number or Link
Resolve #366 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed the status field in the ProductDetails API from postStatus to productStatus to align naming with domain terminology. Client integrations referencing the old field name must update to the new name.
  - Corresponding accessor method updated to productStatus(). No behavioral changes otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->