### PR TITLE
[ENHANCEMENT] 채팅방 생성 API 중복 시 기존 채팅방 ID 반환 기능 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceImpl.java
@@ -64,7 +64,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		// 2. 채팅을 건 유저를 조회
 		Long senderId = apiUserResolver.getCurrentUserId();
 
-		// 3. 채팅방 중복 검증(이미 있는 채팅방)
+		// 3. 채팅방 중복 검증(이미 있는 채팅방이면 해당 ID와 함께 예외 발생)
 		chatRoomValidator.validateDuplicateChatRoom(referenceId, senderId, chatType);
 
 		// 4. 채팅방 생성(생성 시 검증 이루어짐(sender != receiver))

--- a/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomJpaRepository.java
@@ -1,5 +1,7 @@
 package com.cotato.kampus.domain.chat.dao.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +19,6 @@ public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Lon
 		"WHERE c.initialSenderId = :userId OR c.initialReceiverId = :userId " +
 		"ORDER BY c.createdTime DESC")
 	Slice<ChatRoomEntity> findAllByUserIdOrderByCreatedTimeDesc(@Param("userId") Long userId, Pageable pageable);
+
+	Optional<ChatRoomEntity> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long senderId, ChatType chatType);
 }

--- a/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomJpaRepository.java
@@ -20,5 +20,5 @@ public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Lon
 		"ORDER BY c.createdTime DESC")
 	Slice<ChatRoomEntity> findAllByUserIdOrderByCreatedTimeDesc(@Param("userId") Long userId, Pageable pageable);
 
-	Optional<ChatRoomEntity> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long senderId, ChatType chatType);
+	Optional<ChatRoomEntity> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long initialSenderId, ChatType chatType);
 }

--- a/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomRepositoryImpl.java
@@ -29,7 +29,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
 	public Optional<ChatRoom> findById(Long chatroomId) {
 		return chatRoomJpaRepository.findById(chatroomId).map(ChatRoomEntity::toDomain);
 	}
-	
+
 	@Override
 	public boolean existsByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long senderId, ChatType chatType) {
 		return chatRoomJpaRepository.existsByReferenceIdAndInitialSenderIdAndChatType(referenceId, senderId, chatType);
@@ -38,6 +38,14 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
 	@Override
 	public Slice<ChatRoom> findAllByUserIdOrderByCreatedTimeDesc(Long userId, Pageable pageable) {
 		return chatRoomJpaRepository.findAllByUserIdOrderByCreatedTimeDesc(userId, pageable)
+			.map(ChatRoomEntity::toDomain);
+	}
+
+
+	@Override
+	public Optional<ChatRoom> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long senderId,
+		ChatType chatType) {
+		return chatRoomJpaRepository.findByReferenceIdAndInitialSenderIdAndChatType(referenceId, senderId, chatType)
 			.map(ChatRoomEntity::toDomain);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/dao/repository/ChatRoomRepositoryImpl.java
@@ -41,11 +41,10 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
 			.map(ChatRoomEntity::toDomain);
 	}
 
-
 	@Override
-	public Optional<ChatRoom> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long senderId,
+	public Optional<ChatRoom> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long initialSenderId,
 		ChatType chatType) {
-		return chatRoomJpaRepository.findByReferenceIdAndInitialSenderIdAndChatType(referenceId, senderId, chatType)
+		return chatRoomJpaRepository.findByReferenceIdAndInitialSenderIdAndChatType(referenceId, initialSenderId, chatType)
 			.map(ChatRoomEntity::toDomain);
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/ChatRoomFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/ChatRoomFinder.java
@@ -33,6 +33,11 @@ public class ChatRoomFinder {
 			.orElseThrow(() -> new AppException(ErrorCode.CHATROOM_NOT_FOUND));
 	}
 
+	public ChatRoom findByReferenceIdAndSenderIdAndChatType(Long referenceId, Long senderId, ChatType chatType) {
+		return chatRoomRepository.findByReferenceIdAndInitialSenderIdAndChatType(referenceId, senderId, chatType)
+			.orElseThrow(() -> new AppException(ErrorCode.CHATROOM_NOT_FOUND));
+	}
+
 	public Slice<ChatRoom> findChatRooms(Long userId, int page) {
 		CustomPageRequest customPageRequest = new CustomPageRequest(page, PAGE_SIZE, Sort.Direction.DESC);
 		return chatRoomRepository.findAllByUserIdOrderByCreatedTimeDesc(

--- a/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/ChatRoomValidator.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/ChatRoomValidator.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.cotato.kampus.domain.chat.domain.ChatRoom;
 import com.cotato.kampus.domain.chat.enums.ChatType;
 import com.cotato.kampus.global.error.ErrorCode;
-import com.cotato.kampus.global.error.exception.AppException;
+import com.cotato.kampus.global.error.exception.ChatRoomDuplicatedException;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,8 @@ public class ChatRoomValidator {
 	// 채팅방이 이미 존재하는 경우
 	public void validateDuplicateChatRoom(Long referenceId, Long senderId, ChatType chatType) {
 		if (chatRoomFinder.existsByReferenceIdAndSenderIdAndChatType(referenceId, senderId, chatType)) {
-			throw new AppException(ErrorCode.CHATROOM_DUPLICATED);
+			Long existingChatRoomId = chatRoomFinder.findByReferenceIdAndSenderIdAndChatType(referenceId, senderId, chatType).getId();
+			throw new ChatRoomDuplicatedException(ErrorCode.CHATROOM_DUPLICATED, existingChatRoomId);
 		}
 	}
 

--- a/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/port/ChatRoomRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/port/ChatRoomRepository.java
@@ -18,5 +18,5 @@ public interface ChatRoomRepository {
 
 	Optional<ChatRoom> findById(Long chatroomId);
 
-	Optional<ChatRoom> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long senderId, ChatType chatType);
+	Optional<ChatRoom> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long initialSenderId, ChatType chatType);
 }

--- a/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/port/ChatRoomRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/chat/implement/chatroom/port/ChatRoomRepository.java
@@ -17,4 +17,6 @@ public interface ChatRoomRepository {
 	Slice<ChatRoom> findAllByUserIdOrderByCreatedTimeDesc(Long userId, Pageable pageable);
 
 	Optional<ChatRoom> findById(Long chatroomId);
+
+	Optional<ChatRoom> findByReferenceIdAndInitialSenderIdAndChatType(Long referenceId, Long senderId, ChatType chatType);
 }

--- a/src/main/java/com/cotato/kampus/global/error/exception/ChatRoomDuplicatedException.java
+++ b/src/main/java/com/cotato/kampus/global/error/exception/ChatRoomDuplicatedException.java
@@ -1,0 +1,18 @@
+package com.cotato.kampus.global.error.exception;
+
+import com.cotato.kampus.global.error.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomDuplicatedException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final Long existingChatRoomId;
+
+	public ChatRoomDuplicatedException(ErrorCode errorCode, Long existingChatRoomId) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.existingChatRoomId = existingChatRoomId;
+	}
+}

--- a/src/test/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceTest.java
@@ -32,6 +32,7 @@ import com.cotato.kampus.domain.chat.implement.metadata.ChatroomMetadataMapper;
 import com.cotato.kampus.domain.common.application.ApiUserResolver;
 import com.cotato.kampus.global.error.ErrorCode;
 import com.cotato.kampus.global.error.exception.AppException;
+import com.cotato.kampus.global.error.exception.ChatRoomDuplicatedException;
 
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceTest {
@@ -113,7 +114,7 @@ class ChatRoomServiceTest {
 		when(referenceFinder.find(1L, null)).thenReturn(chatReference);
 		when(apiUserResolver.getCurrentUserId()).thenReturn(1L);
 		doNothing().when(chatRoomValidator).validateDuplicateChatRoom(1L, 1L, null);
-		when(chatRoomAppender.appendChatRoom(2L, null, 1L, 2L)).thenReturn(123L);
+		when(chatRoomAppender.appendChatRoom(1L, null, 1L, 2L)).thenReturn(123L);
 		doNothing().when(chatroomMetadataAppender)
 			.createMetadataPair(123L, null, chatReference.getReferenceId(),
 				chatReference.getTitle(), 1L, 2L);
@@ -169,5 +170,102 @@ class ChatRoomServiceTest {
 
 		var result = target.findChatRooms(1, null);
 		assertThat(result.chatRoomPreviewList()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("중복된 채팅방 생성 시 ChatRoomDuplicatedException이 발생하고 기존 채팅방 ID를 포함한다.")
+	void createChatRoom_duplicated() {
+		// given
+		Long referenceId = 1L;
+		Long senderId = 2L;
+		Long existingChatRoomId = 999L;
+
+		ChatReference chatReference = ChatReference.builder()
+			.referenceId(referenceId)
+			.referenceUserId(3L)
+			.title("test")
+			.build();
+
+		when(referenceFinder.find(referenceId, ChatType.POST)).thenReturn(chatReference);
+		when(apiUserResolver.getCurrentUserId()).thenReturn(senderId);
+		doThrow(new ChatRoomDuplicatedException(ErrorCode.CHATROOM_DUPLICATED, existingChatRoomId))
+			.when(chatRoomValidator).validateDuplicateChatRoom(referenceId, senderId, ChatType.POST);
+
+		// when & then
+		assertThatThrownBy(() -> target.createChatRoom(referenceId, ChatType.POST))
+			.isInstanceOf(ChatRoomDuplicatedException.class)
+			.hasMessage(ErrorCode.CHATROOM_DUPLICATED.getMessage())
+			.extracting("existingChatRoomId")
+			.isEqualTo(existingChatRoomId);
+
+		// 중복 검증 이후 채팅방 생성 로직이 실행되지 않는지 확인
+		verify(chatRoomAppender, never()).appendChatRoom(any(), any(), any(), any());
+		verify(chatroomMetadataAppender, never()).createMetadataPair(any(), any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("중복된 PRODUCT 타입 채팅방 생성 시에도 ChatRoomDuplicatedException이 발생한다.")
+	void createChatRoom_duplicated_product() {
+		// given
+		Long referenceId = 1L;
+		Long senderId = 2L;
+		Long existingChatRoomId = 888L;
+
+		ChatReference chatReference = ChatReference.builder()
+			.referenceId(referenceId)
+			.referenceUserId(3L)
+			.title("product test")
+			.build();
+
+		when(referenceFinder.find(referenceId, ChatType.PRODUCT)).thenReturn(chatReference);
+		when(apiUserResolver.getCurrentUserId()).thenReturn(senderId);
+		doThrow(new ChatRoomDuplicatedException(ErrorCode.CHATROOM_DUPLICATED, existingChatRoomId))
+			.when(chatRoomValidator).validateDuplicateChatRoom(referenceId, senderId, ChatType.PRODUCT);
+
+		// when & then
+		assertThatThrownBy(() -> target.createChatRoom(referenceId, ChatType.PRODUCT))
+			.isInstanceOf(ChatRoomDuplicatedException.class)
+			.hasMessage(ErrorCode.CHATROOM_DUPLICATED.getMessage())
+			.extracting("existingChatRoomId")
+			.isEqualTo(existingChatRoomId);
+	}
+
+	@Test
+	@DisplayName("중복 검증 통과 후 채팅방이 정상적으로 생성된다.")
+	void createChatRoom_success_after_validation() {
+		// given
+		Long referenceId = 1L;
+		Long senderId = 2L;
+		Long receiverId = 3L;
+		Long expectedChatRoomId = 100L;
+
+		ChatReference chatReference = ChatReference.builder()
+			.referenceId(referenceId)
+			.referenceUserId(receiverId)
+			.title("test chat")
+			.build();
+
+		when(referenceFinder.find(referenceId, ChatType.POST)).thenReturn(chatReference);
+		when(apiUserResolver.getCurrentUserId()).thenReturn(senderId);
+		doNothing().when(chatRoomValidator).validateDuplicateChatRoom(referenceId, senderId, ChatType.POST);
+		when(chatRoomAppender.appendChatRoom(referenceId, ChatType.POST, senderId, receiverId))
+			.thenReturn(expectedChatRoomId);
+		doNothing().when(chatroomMetadataAppender)
+			.createMetadataPair(expectedChatRoomId, ChatType.POST, referenceId,
+				chatReference.getTitle(), senderId, receiverId);
+
+		// when
+		Long result = target.createChatRoom(referenceId, ChatType.POST);
+
+		// then
+		assertThat(result).isEqualTo(expectedChatRoomId);
+
+		// 모든 단계가 순서대로 실행되는지 확인
+		verify(referenceFinder).find(referenceId, ChatType.POST);
+		verify(apiUserResolver).getCurrentUserId();
+		verify(chatRoomValidator).validateDuplicateChatRoom(referenceId, senderId, ChatType.POST);
+		verify(chatRoomAppender).appendChatRoom(referenceId, ChatType.POST, senderId, receiverId);
+		verify(chatroomMetadataAppender).createMetadataPair(
+			expectedChatRoomId, ChatType.POST, referenceId, chatReference.getTitle(), senderId, receiverId);
 	}
 }

--- a/src/test/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/com/cotato/kampus/domain/chat/application/ChatRoomServiceTest.java
@@ -228,6 +228,9 @@ class ChatRoomServiceTest {
 			.hasMessage(ErrorCode.CHATROOM_DUPLICATED.getMessage())
 			.extracting("existingChatRoomId")
 			.isEqualTo(existingChatRoomId);
+
+		verify(chatRoomAppender, never()).appendChatRoom(any(), any(), any(), any());
+		verify(chatroomMetadataAppender, never()).createMetadataPair(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
채팅방 생성 시 중복된 채팅방이 존재할 경우, 기존처럼 단순히 예외만 발생시키는 것이 아니라 기존 채팅방의 ID를 함께 반환하여 클라이언트가 해당 채팅방으로 이동할 수 있도록 개선했습니다.

### 상세 내용(Describe your changes)
 **1. 커스텀 예외 클래스 추가**
  - `ChatRoomDuplicatedException` 클래스 생성
  - 기존 채팅방 ID(`existingChatRoomId`)를 포함하여 클라이언트에서 활용 가능

 **2. 중복 검증 로직 개선**
  - `ChatRoomValidator`에서 기존 `AppException` 대신 `ChatRoomDuplicatedException` 발생
  - 중복된 채팅방 발견 시 해당 채팅방의 ID를 예외에 포함하여 전달

  **3. 테스트 코드 추가**
  - 중복 채팅방 생성 시 커스텀 예외 발생 테스트 추가
  - POST/PRODUCT 타입별 중복 처리 테스트 추가
  - 정상 채팅방 생성 프로세스 검증 테스트 추가
  - 기존 테스트 버그 수정


### Issue Number or Link
Resolve #368 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Starting a chat that already exists now raises a specific error including the existing chat room ID so clients can redirect or reuse the conversation.
  - Duplicate detection improved for composite identifiers (reference, sender, chat type) for more consistent behavior.

- **Tests**
  - Added tests covering duplicate chat room scenarios and successful creation flows to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->