### PR TITLE
[FIX] ChatRoomDuplicatedException 예외 핸들러 추가

### DIFF
--- a/src/main/java/com/cotato/kampus/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/cotato/kampus/global/error/handler/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 
 import com.cotato.kampus.global.error.ErrorCode;
 import com.cotato.kampus.global.error.exception.AppException;
+import com.cotato.kampus.global.error.exception.ChatRoomDuplicatedException;
 import com.cotato.kampus.global.error.exception.ImageException;
 import com.cotato.kampus.global.error.exception.ImageValidationException;
 import com.cotato.kampus.global.error.exception.UnivCertException;
@@ -189,5 +190,14 @@ public class GlobalExceptionHandler {
 		log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MALFORMED_TOKEN, request);
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+	}
+
+	@ExceptionHandler(ChatRoomDuplicatedException.class)
+	public ResponseEntity<ErrorResponse> handleChatRoomDuplicatedException(ChatRoomDuplicatedException e, HttpServletRequest request) {
+		log.error("ChatRoom Duplicated Exception 발생: {}, 기존 채팅방 ID: {}", e.getMessage(), e.getExistingChatRoomId());
+		log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request);
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+			.body(errorResponse);
 	}
 }


### PR DESCRIPTION
- 중복 채팅방 예외 발생 시 적절한 에러 응답을 반환하도록 GlobalExceptionHandler에 핸들러를 추가했습니다.

---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
중복 채팅방 예외 발생 시 적절한 에러 응답을 반환하도록 GlobalExceptionHandler에
  ChatRoomDuplicatedException 핸들러를 추가했습니다.


### 상세 내용(Describe your changes)


### Issue Number or Link
Resolve #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when attempting to create a chat room that already exists. The app now returns a clear, consistent error message with an appropriate status code instead of a generic failure.
  * Standardized error response format for this case, enhancing client reliability and reducing confusion.
  * Prevents duplicate chat room operations from proceeding, guiding users to use the existing room.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->