### PR TITLE
[FIX] 댓글 삭제 로직 개선 및 상태별 조회/마스킹 처리

### DIFF
--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
@@ -30,7 +30,10 @@ public class CommentDeleter {
 	@Transactional
 	public void delete(CommentDto commentDto) {
 		Comment comment = commentFinder.findComment(commentDto.commentId());
-		boolean hasReplies = commentRepository.existsByParentId(commentDto.commentId());
+		boolean hasReplies = commentRepository.existsByParentIdAndCommentStatusIn(
+			commentDto.commentId(),
+			CommentStatus.getVisibleStatuses()
+			);
 
 		// 댓글 좋아요 삭제 처리한다
 		commentLikeDeleter.deleteAllByCommentId(commentDto.commentId());

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
@@ -47,6 +47,26 @@ public class CommentDeleter {
 			postUpdater.decreaseCommentCount(post);
 			comment.setCommentStatus(CommentStatus.REMOVED);
 		}
+
+		// 부모 댓글이 있다면 부모의 상태 재검사
+		if (comment.getParentId() != null) {
+			checkAndUpdateParentStatus(comment.getParentId());
+		}
+	}
+
+	private void checkAndUpdateParentStatus(Long parentId) {
+		Comment parent = commentFinder.findComment(parentId);
+		if (parent.getCommentStatus().isMasked()) {
+			boolean hasVisibleReplies = commentRepository
+				.existsByParentIdAndCommentStatusIn(parentId, CommentStatus.getVisibleStatuses());
+
+			if (!hasVisibleReplies) {
+				// 마스킹된 부모 댓글에 가시적 대댓글이 없으면 완전 삭제
+				Post post = postFinder.find(parent.getPostId());
+				postUpdater.decreaseCommentCount(post);
+				parent.setCommentStatus(CommentStatus.REMOVED);
+			}
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
@@ -43,7 +43,7 @@ public class CommentDeleter {
 			comment.setCommentStatus(CommentStatus.MASKED);
 		} else {
 			// 대댓글이 없는 경우: REMOVED 상태로 변경, 댓글 수 감소
-			Post post = postFinder.find(commentDto.postId());
+			Post post = postFinder.find(comment.getPostId());
 			postUpdater.decreaseCommentCount(post);
 			comment.setCommentStatus(CommentStatus.REMOVED);
 		}

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentDeleter.java
@@ -29,20 +29,21 @@ public class CommentDeleter {
 
 	@Transactional
 	public void delete(CommentDto commentDto) {
-		// 대댓글이 없는 댓글이 삭제될 때만 게시글의 전체 댓글 수를 감소시킨다
-		// 대댓글이 있다면 "삭제된 댓글입니다"로 내용만 마스킹 처리되므로 전체 댓글 수는 유지된다
-		boolean hasReplies = commentRepository.existsByParentId(commentDto.commentId());
-		if(!hasReplies) {
-			Post post = postFinder.find(commentDto.postId());
-			postUpdater.decreaseCommentCount(post);
-		}
-
-		// 댓글을 논리적으로 삭제 처리한다
 		Comment comment = commentFinder.findComment(commentDto.commentId());
-		comment.setCommentStatus(CommentStatus.DELETED_BY_USER);
+		boolean hasReplies = commentRepository.existsByParentId(commentDto.commentId());
 
 		// 댓글 좋아요 삭제 처리한다
 		commentLikeDeleter.deleteAllByCommentId(commentDto.commentId());
+
+		if (hasReplies) {
+			// 대댓글이 있는 부모 댓글: 마스킹 처리, 댓글 수 유지
+			comment.setCommentStatus(CommentStatus.MASKED);
+		} else {
+			// 대댓글이 없는 경우: REMOVED 상태로 변경, 댓글 수 감소
+			Post post = postFinder.find(commentDto.postId());
+			postUpdater.decreaseCommentCount(post);
+			comment.setCommentStatus(CommentStatus.REMOVED);
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentFinder.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.cotato.kampus.domain.comment.dao.CommentRepository;
 import com.cotato.kampus.domain.comment.domain.Comment;
 import com.cotato.kampus.domain.comment.dto.CommentDto;
+import com.cotato.kampus.domain.comment.enums.CommentStatus;
 import com.cotato.kampus.global.error.ErrorCode;
 import com.cotato.kampus.global.error.exception.AppException;
 
@@ -32,10 +33,16 @@ public class CommentFinder {
 	public List<CommentDto> findAllDtoByPostId(Long postId) {
 		List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedTimeAsc(postId);
 		List<CommentDto> commentDtos = comments.stream()
+			.filter(comment -> !isRemovedStatus(comment.getCommentStatus()))
 			.map(CommentDto::from)
 			.toList();
 
 		return commentDtos;
+	}
+
+	private boolean isRemovedStatus(CommentStatus status) {
+		return status == CommentStatus.REMOVED
+			|| status == CommentStatus.REMOVED_BY_ADMIN;
 	}
 
 	public List<Comment> findAllByPostId(Long postId) {

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentFinder.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentFinder.java
@@ -33,16 +33,11 @@ public class CommentFinder {
 	public List<CommentDto> findAllDtoByPostId(Long postId) {
 		List<Comment> comments = commentRepository.findAllByPostIdOrderByCreatedTimeAsc(postId);
 		List<CommentDto> commentDtos = comments.stream()
-			.filter(comment -> !isRemovedStatus(comment.getCommentStatus()))
+			.filter(comment -> !comment.getCommentStatus().isRemoved())
 			.map(CommentDto::from)
 			.toList();
 
 		return commentDtos;
-	}
-
-	private boolean isRemovedStatus(CommentStatus status) {
-		return status == CommentStatus.REMOVED
-			|| status == CommentStatus.REMOVED_BY_ADMIN;
 	}
 
 	public List<Comment> findAllByPostId(Long postId) {

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
@@ -68,7 +68,7 @@ public class CommentMapper {
 			);
 
 			// MASKED 상태인 경우 마스킹 처리
-			if (isMaskedStatus(dto.commentStatus())) {
+			if (dto.commentStatus().isMasked()) {
 				detail = detail.withMaskedContent();
 			}
 
@@ -127,10 +127,6 @@ public class CommentMapper {
 
 		rootComments.sort(Comparator.comparing(CommentDetail::createdTime));
 		return rootComments;
-	}
-
-	private boolean isMaskedStatus(CommentStatus status) {
-		return status == CommentStatus.MASKED || status == CommentStatus.MASKED_BY_ADMIN;
 	}
 
 	/**

--- a/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/application/CommentMapper.java
@@ -51,13 +51,13 @@ public class CommentMapper {
 	/**
 	 * CommentDto를 CommentDetail로 변환하여 Map에 저장
 	 */
-	private Map<Long, CommentDetail> convertToCommentDetails(List<CommentDto> allCommentDtos, 
+	private Map<Long, CommentDetail> convertToCommentDetails(List<CommentDto> allCommentDtos,
 			Map<Long, CommentDto> commentDtoMap, Map<Long, Boolean> likedCommentsMap, Long userId) {
 		Map<Long, CommentDetail> commentMap = new HashMap<>();
-		
+
 		for (CommentDto dto : allCommentDtos) {
 			String targetAuthor = resolveTargetAuthor(dto, commentDtoMap);
-			
+
 			CommentDetail detail = CommentDetail.of(
 				dto,
 				anonymousNumberAllocator.resolveAuthorName(dto),
@@ -66,6 +66,12 @@ public class CommentMapper {
 				likedCommentsMap.getOrDefault(dto.commentId(), false),
 				userId.equals(dto.userId())
 			);
+
+			// MASKED 상태인 경우 마스킹 처리
+			if (isMaskedStatus(dto.commentStatus())) {
+				detail = detail.withMaskedContent();
+			}
+
 			commentMap.put(dto.commentId(), detail);
 		}
 		return commentMap;
@@ -111,24 +117,20 @@ public class CommentMapper {
 	 */
 	private List<CommentDetail> filterAndSortRootComments(Map<Long, CommentDetail> commentMap) {
 		List<CommentDetail> rootComments = new ArrayList<>();
-		
+
 		for(CommentDetail detail : commentMap.values()) {
 			if(detail.parentId() == null) {
-				boolean isDeleted = detail.commentStatus() != CommentStatus.NORMAL;
-				boolean hasReplies = !detail.replies().isEmpty();
-
-				if (isDeleted && hasReplies) {
-					// 삭제됐지만 대댓글이 있는 경우: 내용 변경 후 추가
-					rootComments.add(detail.withMaskedContent());
-				} else if (!isDeleted) {
-					rootComments.add(detail);
-				}
-				// 삭제됐고 대댓글도 없는 경우는 아무것도 하지 않음 (결과에서 제외)
+				// 이미 convertToCommentDetails에서 마스킹 처리했으므로 그대로 추가
+				rootComments.add(detail);
 			}
 		}
-		
+
 		rootComments.sort(Comparator.comparing(CommentDetail::createdTime));
 		return rootComments;
+	}
+
+	private boolean isMaskedStatus(CommentStatus status) {
+		return status == CommentStatus.MASKED || status == CommentStatus.MASKED_BY_ADMIN;
 	}
 
 	/**

--- a/src/main/java/com/cotato/kampus/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dao/CommentRepository.java
@@ -1,8 +1,8 @@
 package com.cotato.kampus.domain.comment.dao;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,7 +17,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	Optional<Comment> findFirstByPostIdAndUserId(Long postId, Long userId);
 
-	boolean existsByParentIdAndCommentStatusIn(Long commentId, Set<CommentStatus> commentStatuses);
+	boolean existsByParentIdAndCommentStatusIn(Long parentId, Collection<CommentStatus> statuses);
 
 	List<Comment> findAllByPostIdOrderByCreatedTimeAsc(Long postId);
 

--- a/src/main/java/com/cotato/kampus/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/dao/CommentRepository.java
@@ -2,33 +2,25 @@ package com.cotato.kampus.domain.comment.dao;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.cotato.kampus.domain.comment.domain.Comment;
+import com.cotato.kampus.domain.comment.enums.CommentStatus;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	Optional<Comment> findFirstByPostIdAndUserId(Long postId, Long userId);
 
-	boolean existsByParentId(Long parentId);
+	boolean existsByParentIdAndCommentStatusIn(Long commentId, Set<CommentStatus> commentStatuses);
 
 	List<Comment> findAllByPostIdOrderByCreatedTimeAsc(Long postId);
 
 	Slice<Comment> findAllByUserId(Long userId, Pageable pageable);
 
-	@Query("""
-		SELECT c.postId 
-		FROM Comment c
-		WHERE c.userId = :userId
-		GROUP BY c.postId
-		ORDER BY MAX(c.createdTime) DESC
-		""")
-	List<Long> findRecentPostIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/cotato/kampus/domain/comment/domain/Comment.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/domain/Comment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +20,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "comment")
+@Table(
+	name = "comment",
+	indexes = {
+		@Index(name = "idx_comment_parent_status", columnList = "parent_id, comment_status"),
+		@Index(name = "idx_comment_post", columnList = "post_id")
+	}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeEntity {

--- a/src/main/java/com/cotato/kampus/domain/comment/domain/Comment.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/domain/Comment.java
@@ -20,13 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-	name = "comment",
-	indexes = {
-		@Index(name = "idx_comment_parent_status", columnList = "parent_id, comment_status"),
-		@Index(name = "idx_comment_post", columnList = "post_id")
-	}
-)
+@Table(name = "comment")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeEntity {

--- a/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
@@ -1,5 +1,6 @@
 package com.cotato.kampus.domain.comment.enums;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 public enum CommentStatus {
@@ -9,6 +10,8 @@ public enum CommentStatus {
 	MASKED_BY_ADMIN,
 	REMOVED_BY_ADMIN;
 
+	private static final Set<CommentStatus> VISIBLE_STATUSES = EnumSet.of(NORMAL, MASKED, REMOVED);
+
 	public boolean isRemoved() {
 		return this == REMOVED || this == REMOVED_BY_ADMIN;
 	}
@@ -17,7 +20,11 @@ public enum CommentStatus {
 		return this == MASKED || this == MASKED_BY_ADMIN;
 	}
 
+	public boolean isVisible() {
+		return this == NORMAL || isMasked();
+	}
+
 	public static Set<CommentStatus> getVisibleStatuses() {
-		return Set.of(NORMAL, MASKED, MASKED_BY_ADMIN);
+		return VISIBLE_STATUSES;
 	}
 }

--- a/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
@@ -1,5 +1,9 @@
 package com.cotato.kampus.domain.comment.enums;
 
 public enum CommentStatus {
-	NORMAL, DELETED_BY_USER, DELETED_BY_ADMIN
+	NORMAL,
+	MASKED, // 마스킹 표시 (대댓글 떄문에 남겨둠)
+	REMOVED, // 완전 제거 (조회에서 제외)
+	MASKED_BY_ADMIN,
+	REMOVED_BY_ADMIN
 }

--- a/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
@@ -10,7 +10,7 @@ public enum CommentStatus {
 	MASKED_BY_ADMIN,
 	REMOVED_BY_ADMIN;
 
-	private static final Set<CommentStatus> VISIBLE_STATUSES = EnumSet.of(NORMAL, MASKED, REMOVED);
+	private static final Set<CommentStatus> VISIBLE_STATUSES = EnumSet.of(NORMAL, MASKED, MASKED_BY_ADMIN);
 
 	public boolean isRemoved() {
 		return this == REMOVED || this == REMOVED_BY_ADMIN;

--- a/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
+++ b/src/main/java/com/cotato/kampus/domain/comment/enums/CommentStatus.java
@@ -1,9 +1,23 @@
 package com.cotato.kampus.domain.comment.enums;
 
+import java.util.Set;
+
 public enum CommentStatus {
 	NORMAL,
-	MASKED, // 마스킹 표시 (대댓글 떄문에 남겨둠)
+	MASKED, // 마스킹 표시 (대댓글 때문에 남겨둠)
 	REMOVED, // 완전 제거 (조회에서 제외)
 	MASKED_BY_ADMIN,
-	REMOVED_BY_ADMIN
+	REMOVED_BY_ADMIN;
+
+	public boolean isRemoved() {
+		return this == REMOVED || this == REMOVED_BY_ADMIN;
+	}
+
+	public boolean isMasked() {
+		return this == MASKED || this == MASKED_BY_ADMIN;
+	}
+
+	public static Set<CommentStatus> getVisibleStatuses() {
+		return Set.of(NORMAL, MASKED, MASKED_BY_ADMIN);
+	}
 }

--- a/src/test/java/com/cotato/kampus/domain/comment/application/CommentFinderTest.java
+++ b/src/test/java/com/cotato/kampus/domain/comment/application/CommentFinderTest.java
@@ -1,0 +1,225 @@
+package com.cotato.kampus.domain.comment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cotato.kampus.domain.comment.dao.CommentRepository;
+import com.cotato.kampus.domain.comment.domain.Comment;
+import com.cotato.kampus.domain.comment.dto.CommentDto;
+import com.cotato.kampus.domain.comment.enums.CommentStatus;
+import com.cotato.kampus.domain.comment.enums.ReportStatus;
+import com.cotato.kampus.domain.common.enums.Anonymity;
+
+@ExtendWith(MockitoExtension.class)
+class CommentFinderTest {
+
+	@InjectMocks
+	private CommentFinder commentFinder;
+
+	@Mock
+	private CommentRepository commentRepository;
+
+	@Test
+	@DisplayName("REMOVED 상태 댓글은 조회에서 제외되어야 한다")
+	void findAllDtoByPostId_removedComment_shouldExclude() {
+		// given
+		Long postId = 1L;
+
+		Comment normalComment = Comment.builder()
+			.userId(1L)
+			.postId(postId)
+			.content("Normal comment")
+			.likes(0L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.NORMAL)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(1)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		Comment removedComment = Comment.builder()
+			.userId(2L)
+			.postId(postId)
+			.content("Removed comment")
+			.likes(0L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.REMOVED)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(2)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		Comment maskedComment = Comment.builder()
+			.userId(3L)
+			.postId(postId)
+			.content("Masked comment")
+			.likes(0L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.MASKED)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(3)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		given(commentRepository.findAllByPostIdOrderByCreatedTimeAsc(postId))
+			.willReturn(Arrays.asList(normalComment, removedComment, maskedComment));
+
+		// when
+		List<CommentDto> result = commentFinder.findAllDtoByPostId(postId);
+
+		// then
+		assertThat(result).hasSize(2); // REMOVED 댓글은 제외
+
+		List<CommentStatus> resultStatuses = result.stream()
+			.map(CommentDto::commentStatus)
+			.toList();
+
+		assertThat(resultStatuses).containsExactly(CommentStatus.NORMAL, CommentStatus.MASKED);
+		assertThat(resultStatuses).doesNotContain(CommentStatus.REMOVED);
+	}
+
+	@Test
+	@DisplayName("NORMAL과 MASKED 상태 댓글은 조회에 포함되어야 한다")
+	void findAllDtoByPostId_normalAndMaskedComments_shouldInclude() {
+		// given
+		Long postId = 1L;
+
+		Comment normalComment = Comment.builder()
+			.userId(1L)
+			.postId(postId)
+			.content("Normal comment")
+			.likes(3L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.NORMAL)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(1)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		Comment maskedComment = Comment.builder()
+			.userId(2L)
+			.postId(postId)
+			.content("Masked comment")
+			.likes(7L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.MASKED)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(2)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		Comment maskedByAdminComment = Comment.builder()
+			.userId(3L)
+			.postId(postId)
+			.content("Masked by admin comment")
+			.likes(2L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.MASKED_BY_ADMIN)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(3)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		given(commentRepository.findAllByPostIdOrderByCreatedTimeAsc(postId))
+			.willReturn(Arrays.asList(normalComment, maskedComment, maskedByAdminComment));
+
+		// when
+		List<CommentDto> result = commentFinder.findAllDtoByPostId(postId);
+
+		// then
+		assertThat(result).hasSize(3); // 모든 댓글 포함
+
+		List<CommentStatus> resultStatuses = result.stream()
+			.map(CommentDto::commentStatus)
+			.toList();
+
+		assertThat(resultStatuses).containsExactly(
+			CommentStatus.NORMAL,
+			CommentStatus.MASKED,
+			CommentStatus.MASKED_BY_ADMIN
+		);
+	}
+
+	@Test
+	@DisplayName("모든 댓글이 REMOVED 상태이면 빈 리스트를 반환해야 한다")
+	void findAllDtoByPostId_allRemovedComments_shouldReturnEmpty() {
+		// given
+		Long postId = 1L;
+
+		Comment removedComment1 = Comment.builder()
+			.userId(1L)
+			.postId(postId)
+			.content("Removed comment 1")
+			.likes(0L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.REMOVED)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(1)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		Comment removedComment2 = Comment.builder()
+			.userId(2L)
+			.postId(postId)
+			.content("Removed comment 2")
+			.likes(0L)
+			.reportStatus(ReportStatus.NORMAL)
+			.commentStatus(CommentStatus.REMOVED_BY_ADMIN)
+			.anonymity(Anonymity.ANONYMOUS)
+			.reports(0L)
+			.anonymousNumber(2)
+			.parentId(null)
+			.targetId(null)
+			.build();
+
+		given(commentRepository.findAllByPostIdOrderByCreatedTimeAsc(postId))
+			.willReturn(Arrays.asList(removedComment1, removedComment2));
+
+		// when
+		List<CommentDto> result = commentFinder.findAllDtoByPostId(postId);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("댓글이 없으면 빈 리스트를 반환해야 한다")
+	void findAllDtoByPostId_noComments_shouldReturnEmpty() {
+		// given
+		Long postId = 1L;
+
+		given(commentRepository.findAllByPostIdOrderByCreatedTimeAsc(postId))
+			.willReturn(Arrays.asList());
+
+		// when
+		List<CommentDto> result = commentFinder.findAllDtoByPostId(postId);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+}

--- a/src/test/java/com/cotato/kampus/domain/comment/application/CommentMapperTest.java
+++ b/src/test/java/com/cotato/kampus/domain/comment/application/CommentMapperTest.java
@@ -184,7 +184,7 @@ class CommentMapperTest {
 		// 삭제된 부모 댓글
 		CommentDto deletedParent = new CommentDto(
 			10L, 2L, 1L, "Original content", 0L,
-			ReportStatus.NORMAL, CommentStatus.DELETED_BY_USER, // 삭제됨
+			ReportStatus.NORMAL, CommentStatus.MASKED, // 마스킹됨
 			Anonymity.ANONYMOUS, 0L, 1, null, null,
 			LocalDateTime.now()
 		);
@@ -214,39 +214,91 @@ class CommentMapperTest {
 	}
 
 	@Test
-	@DisplayName("삭제된 댓글이고 대댓글도 없으면 결과에서 완전히 제외해야 한다")
-	void buildCommentHierarchy_deletedCommentWithoutReplies_shouldExclude() {
+	@DisplayName("MASKED 상태 댓글은 내용이 마스킹되어 조회되어야 한다")
+	void buildCommentHierarchy_maskedComment_shouldShowMaskedContent() {
 		// given
 		Long currentUserId = 1L;
-		
-		// 삭제된 댓글 (대댓글 없음)
-		CommentDto deletedComment = new CommentDto(
-			10L, 2L, 1L, "To be deleted", 0L,
-			ReportStatus.NORMAL, CommentStatus.DELETED_BY_USER, // 삭제됨
-			Anonymity.ANONYMOUS, 0L, 1, null, null,
-			LocalDateTime.now()
-		);
-		
-		// 정상 댓글
-		CommentDto normalComment = new CommentDto(
-			11L, currentUserId, 1L, "Normal comment", 0L,
-			ReportStatus.NORMAL, CommentStatus.NORMAL,
-			Anonymity.ANONYMOUS, 0L, 2, null, null,
-			LocalDateTime.now().plusMinutes(1)
+		Long maskedCommentId = 10L;
+		Long otherUserId = 2L;
+		Long postId = 1L;
+		String originalContent = "Original sensitive content";
+		LocalDateTime commentTime = LocalDateTime.now();
+
+		CommentDto maskedComment = new CommentDto(
+			maskedCommentId,
+			otherUserId,
+			postId,
+			originalContent,
+			0L, // likes
+			ReportStatus.NORMAL,
+			CommentStatus.MASKED,
+			Anonymity.ANONYMOUS,
+			0L, // reports
+			1, // anonymousNumber
+			null, // parentId
+			null, // targetId
+			commentTime
 		);
 
-		given(anonymousNumberAllocator.resolveAuthorName(deletedComment)).willReturn("Anonymous1");
+		given(anonymousNumberAllocator.resolveAuthorName(maskedComment)).willReturn("Anonymous1");
+		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(eq(currentUserId), anyList()))
+			.willReturn(emptyList());
+
+		// when
+		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
+			Arrays.asList(maskedComment), currentUserId);
+
+		// then
+		assertThat(result).hasSize(1);
+		CommentDetail resultComment = result.get(0);
+
+		assertThat(resultComment.commentId()).isEqualTo(maskedCommentId);
+		assertThat(resultComment.commentStatus()).isEqualTo(CommentStatus.MASKED);
+		assertThat(resultComment.content()).isEqualTo("This comment was deleted.");
+		assertThat(resultComment.content()).isNotEqualTo(originalContent); // 원본 내용과 다름
+	}
+
+	@Test
+	@DisplayName("NORMAL 상태 댓글은 원본 내용이 그대로 조회되어야 한다")
+	void buildCommentHierarchy_normalComment_shouldShowOriginalContent() {
+		// given
+		Long currentUserId = 1L;
+		Long normalCommentId = 11L;
+		Long postId = 1L;
+		String originalContent = "This is normal comment content";
+		LocalDateTime commentTime = LocalDateTime.now();
+
+		CommentDto normalComment = new CommentDto(
+			normalCommentId,
+			currentUserId,
+			postId,
+			originalContent,
+			0L, // likes
+			ReportStatus.NORMAL,
+			CommentStatus.NORMAL,
+			Anonymity.ANONYMOUS,
+			0L, // reports
+			2, // anonymousNumber
+			null, // parentId
+			null, // targetId
+			commentTime
+		);
+
 		given(anonymousNumberAllocator.resolveAuthorName(normalComment)).willReturn("Anonymous2");
 		given(commentLikeRepository.findCommentIdsByUserIdAndCommentIdIn(eq(currentUserId), anyList()))
 			.willReturn(emptyList());
 
 		// when
 		List<CommentDetail> result = commentMapper.buildCommentHierarchy(
-			Arrays.asList(deletedComment, normalComment), currentUserId);
+			Arrays.asList(normalComment), currentUserId);
 
 		// then
-		assertThat(result).hasSize(1); // 삭제된 댓글은 제외됨
-		assertThat(result.get(0).commentId()).isEqualTo(11L); // 정상 댓글만 포함
+		assertThat(result).hasSize(1);
+		CommentDetail resultComment = result.get(0);
+
+		assertThat(resultComment.commentId()).isEqualTo(normalCommentId);
+		assertThat(resultComment.commentStatus()).isEqualTo(CommentStatus.NORMAL);
+		assertThat(resultComment.content()).isEqualTo(originalContent); // 원본 내용 유지
 	}
 
 	// ========== 좋아요 기능 테스트 ==========


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Describe this issue template's purpose here.
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
댓글 삭제 로직 개선 및 상태 관리 최적화
CommentStatus 재정의 및 캡슐화
상태별 댓글 조회 및 마스킹 처리 기능 구현

### 상세 내용(Describe your changes)
CommentDeleter:
  - 댓글 삭제 로직 개선
  - 대댓글 삭제 시 부모 댓글 상태 재검사 로직 추가 (지연 정리)
  - 마스킹된 부모 댓글에 가시적 대댓글이 없으면 완전 삭제로 전환
 
CommentFinder:
  - 상태별 댓글 조회 기능 추가
  - 삭제된 댓글 필터링 로직을 enum 메서드로 위임

CommentMapper:
  - 마스킹 처리 로직 개선
  - 상태 판별 로직을 enum 메서드로 위임

CommentStatus:
  - enum 재정의 및 메서드 추가
  - isRemoved(), isMasked(), getVisibleStatuses() 메서드로 상태 판별 로직 캡슐화

CommentRepository:
  - 가시적 대댓글 존재 여부 확인을 위한 메서드 추가
  - 불필요한 쿼리 메서드 제거

테스트 코드 추가

### Issue Number or Link
Resolve #376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comments with visible replies are now shown as masked ("This comment was deleted."); comments without replies are removed and post comment counts update. Parent comments are re-evaluated after deletions. Visible/removed filtering now excludes removed comments while preserving normal and masked (including admin-masked) comments.
* **Tests**
  * Added unit tests covering filtering, masking, and removal behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->